### PR TITLE
fix: add delete_policy for openlist offline

### DIFF
--- a/src/openlist_ani/core/download/downloader/api/openlist.py
+++ b/src/openlist_ani/core/download/downloader/api/openlist.py
@@ -100,7 +100,11 @@ class OpenListClient:
             return False
 
     async def add_offline_download(
-        self, urls: List[str], path: str, tool: Union[str, OfflineDownloadTool]
+        self,
+        urls: List[str],
+        path: str,
+        tool: Union[str, OfflineDownloadTool],
+        delete_policy: str = "delete_always",
     ) -> Optional[List[OpenlistTask]]:
         """
         Add offline download tasks.
@@ -113,7 +117,12 @@ class OpenListClient:
             return None
 
         url = f"{self.base_url}/api/fs/add_offline_download"
-        payload = {"urls": urls, "path": path, "tool": str(tool)}
+        payload = {
+            "urls": urls,
+            "path": path,
+            "tool": str(tool),
+            "delete_policy": delete_policy,
+        }
 
         data = await self._post(url, payload)
         if data and data.get("code") == 200:

--- a/src/openlist_ani/core/download/downloader/openlist_downloader.py
+++ b/src/openlist_ani/core/download/downloader/openlist_downloader.py
@@ -183,8 +183,6 @@ class OpenListDownloader(BaseDownloader):
                 return HandlerResult.poll(delay=download_result.poll_delay)
             case _StageStatus.FAILED:
                 return HandlerResult.fail(download_result.error_message)
-            case _StageStatus.COMPLETED | _StageStatus.SKIP:
-                pass
 
         transfer_result = await self._wait_transfer_task_if_exists(task)
         match transfer_result.status:
@@ -192,8 +190,6 @@ class OpenListDownloader(BaseDownloader):
                 return HandlerResult.poll(delay=transfer_result.poll_delay)
             case _StageStatus.FAILED:
                 return HandlerResult.fail(transfer_result.error_message)
-            case _StageStatus.COMPLETED | _StageStatus.SKIP:
-                pass
 
         downloaded_filename = await self._detect_downloaded_file(task)
         if not downloaded_filename:


### PR DESCRIPTION
1. Optimize the downloading process for the offline downloader.
2. Add a delete policy parameter to the Openlist offline download API to fix #70 