### PR TITLE
feat(rss): add more filter for rss

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -5,12 +5,18 @@ port = 26666  # Backend API listening port
 [rss]
 urls = []
 interval_time = 300 # RSS fetch interval in seconds (default: 5 minutes)
+strict = false  # Strict mode: only download entries that can be successfully renamed (requires rename_format)
 
+[rss.filter]
+exclude_patterns = []  # Regex patterns to exclude RSS entries by title (e.g. ["合集", "SP\\d+", "HEVC"])
+exclude_fansub = []  # Blacklist fansub groups (exact match, e.g. ["XX字幕组", "YY字幕组"])
+exclude_quality = []  # Blacklist quality levels (e.g. ["480p"])
+exclude_languages = []  # Blacklist languages (e.g. ["未知"]). Available: "简", "繁", "日", "英", "未知"
 
 [rss.priority]
 field_order = ["fansub", "quality", "languages"]  # Field comparison order, earlier fields take precedence
 fansub = []  # Fansub group priority, earlier = higher (e.g. ["Fansub_A", "Fansub_B"])
-languages = []  # Language priority, earlier = higher (available: "简", "繁", "日", "英")
+languages = []  # Language priority, earlier = higher. Single: "简", "繁", "日", "英"; Combo: "简繁" (CHS+CHT dual). E.g. ["简", "简繁", "繁"]
 quality = ["2160p", "1080p", "720p", "480p"]  # Quality priority, earlier = higher. Set [] to disable
 
 [proxy]

--- a/docs/配置说明.md
+++ b/docs/配置说明.md
@@ -11,6 +11,13 @@ port = 26666  # Backend API listening port
 [rss]
 urls = []
 interval_time = 300 # RSS fetch interval in seconds (default: 5 minutes)
+strict = false  # Strict mode: only download entries that can be successfully renamed
+
+[rss.filter]
+exclude_patterns = []  # Regex patterns to exclude RSS entries by title
+exclude_fansub = []
+exclude_quality = []
+exclude_languages = []
 
 [rss.priority]
 field_order = ["fansub", "quality", "languages"]
@@ -100,6 +107,28 @@ retention = "1 week"  # How long to keep old logs: "1 week", "30 days", "3 month
 |--------|------|--------|------|
 | `urls` | list | `[]` | RSS 订阅链接列表 |
 | `interval_time` | int | `300` | RSS 抓取间隔（秒） |
+| `strict` | bool | `false` | 严格模式：仅下载能成功重命名的条目（需配合 `rename_format` 使用） |
+
+#### rss.filter（过滤与黑名单）
+
+基于正则表达式和 LLM 解析出的元数据（字幕组、清晰度、语言）进行过滤。匹配的资源将被排除。
+
+| 配置项 | 类型 | 默认值 | 说明 |
+|--------|------|--------|------|
+| `exclude_patterns` | list | `[]` | 正则排除模式列表。匹配任一正则的 RSS 条目将被排除（不下载）。使用 `re.search()` 部分匹配 |
+| `exclude_fansub` | list | `[]` | 排除的字幕组列表（精确匹配），如 `["XX字幕组", "YY字幕组"]` |
+| `exclude_quality` | list | `[]` | 排除的清晰度列表（精确匹配），如 `["480p"]` |
+| `exclude_languages` | list | `[]` | 排除的语言列表。资源的任一语言命中即排除。可选值：`"简"`、`"繁"`、`"日"`、`"英"`、`"未知"` |
+
+**示例：**
+
+```toml
+[rss.filter]
+exclude_patterns = ["合集", "SP\\d+"]  # 排除标题含「合集」或「SP+数字」的条目
+exclude_fansub = ["XX字幕组"]  # 排除指定字幕组
+exclude_quality = ["480p"]     # 排除 480p 资源
+exclude_languages = ["未知"]   # 排除语言未知的资源
+```
 
 #### rss.priority（下载优先级）
 
@@ -109,7 +138,7 @@ retention = "1 week"  # How long to keep old logs: "1 week", "30 days", "3 month
 |--------|------|--------|------|
 | `field_order` | list | `["fansub", "quality", "languages"]` | 字段比较优先级顺序（靠前优先级高） |
 | `fansub` | list | `[]` | 字幕组优先级列表（靠前优先级高） |
-| `languages` | list | `[]` | 语言优先级列表（靠前优先级高）。可选值：`"简"`、`"繁"`、`"日"`、`"英"` |
+| `languages` | list | `[]` | 语言优先级列表（靠前优先级高）。单语言：`"简"`、`"繁"`、`"日"`、`"英"`；组合语言：`"简繁"`（简繁双语）等 |
 | `quality` | list | `["2160p", "1080p", "720p", "480p"]` | 清晰度优先级列表（默认高清优先）。设为 `[]` 禁用清晰度过滤 |
 
 **优先级判断逻辑：**
@@ -127,7 +156,7 @@ retention = "1 week"  # How long to keep old logs: "1 week", "30 days", "3 month
 [rss.priority]
 field_order = ["fansub", "quality", "languages"]  # 字幕组 > 清晰度 > 语言
 fansub = ["Fansub_A", "Fansub_B"]  # Fansub_A > Fansub_B > 其他
-languages = ["简", "繁"]        # 简体 > 繁体 > 其他
+languages = ["简", "简繁", "繁"]   # 纯简体 > 简繁双语 > 纯繁体 > 其他
 quality = ["2160p", "1080p", "720p", "480p"]
 ```
 
@@ -135,9 +164,16 @@ quality = ["2160p", "1080p", "720p", "480p"]
 
 1. 若已下载了优先级更高的字幕组（Fansub_A），则所有非 Fansub_A 的字幕组资源均会跳过下载，若已下载了第二优先级的字幕组（Fansub_B），则后续只有Fansub_B和Fansub_A的资源允许被下载。允许被下载的资源，会继续比较下一个字段quality
 2. 以相同的逻辑，比较清晰度的优先级，`["2160p", "1080p", "720p", "480p"]` 意为优先下载清晰度更高的资源。允许被下载的资源，会继续比较下一个字段languages
-3. 以相同的逻辑，比较字幕语言的优先级，`["简", "繁"] ` 意为优先下载简中的资源。
+3. 以相同的逻辑，比较字幕语言的优先级，`["简", "简繁", "繁"]` 意为优先下载纯简体的资源。
 
-优先级为过滤逻辑，未设置优先级，则代表对应的字段不参与过滤，所有资源均会进行下载。若开启优先级过滤，则在经过所有字段的过滤后，剩下的资源才会被下载。
+**语言组合匹配规则：**
+
+语言优先级支持「精确匹配」和「包含匹配」两种模式，精确匹配优先级更高：
+
+- **精确匹配**：将资源的语言列表排序后拼接为字符串（如 `[CHS, CHT]` → `"简繁"`），与配置项精确比较
+- **包含匹配（兜底）**：若无精确匹配，则检查资源的语言字符串是否包含配置中的单字符条目
+
+如，若优先级只设置了["简"]，但实际资源语言为"简繁"时，会先优先搜索配置项是否包含"简繁"，若无，则fallback归纳为"简"，和简体资源优先级同级。若优先级设置为["简", "简繁"], 则当已有纯简体资源下载过时，简繁不会被下载。
 
 ### Proxy（代理）
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,4 +49,4 @@ dev = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-addopts = "-x --dist worksteal -n auto -q"
+norecursedirs = ["tests/manual_test_script"]

--- a/src/openlist_ani/__init__.py
+++ b/src/openlist_ani/__init__.py
@@ -11,6 +11,15 @@ Package layout:
   scripts/    One-off maintenance scripts
 """
 
-from .backend.main import main, run
+
+def __getattr__(name: str):
+    if name in ("main", "run"):
+        from .backend.main import main, run
+
+        globals()["main"] = main
+        globals()["run"] = run
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["main", "run"]

--- a/src/openlist_ani/backend/worker.py
+++ b/src/openlist_ani/backend/worker.py
@@ -8,7 +8,13 @@ from ..core.download import DownloadManager
 from ..core.parser.model import ParseResult
 from ..core.parser.parser import parse_metadata
 from ..core.rss import RSSManager
-from ..core.rss.priority import ResourcePriorityFilter
+from ..core.rss.filter import (
+    FilterChain,
+    MetadataFilter,
+    PriorityFilter,
+    RegexTitleFilter,
+    StrictRenameFilter,
+)
 from ..core.website.model import AnimeResourceInfo
 from ..database import db
 from ..logger import logger
@@ -31,11 +37,14 @@ class RSSPollWorker:
     ) -> None:
         self._rss = rss
         self._queue = queue
-        self._priority_filter = ResourcePriorityFilter()
         self._skip_cache: TTLCache[str, float] = TTLCache(
             maxsize=self._SKIP_CACHE_MAXSIZE, ttl=self._SKIP_CACHE_TTL
         )
         self._last_priority = config.rss.priority.model_copy(deep=True)
+        self._last_strict: bool = config.rss.strict
+        self._last_rename_format: str = config.openlist.rename_format
+        self._last_filter_cfg = config.rss.filter.model_copy(deep=True)
+        self._filter_chain: FilterChain = self._build_filter_chain()
 
     # ── pipeline entry point ─────────────────────────────────────────
 
@@ -53,7 +62,7 @@ class RSSPollWorker:
                 if fresh:
                     logger.info(f"Fetched {len(entries)} entries from RSS feeds")
                     enriched = await self._enrich_by_parser(fresh)
-                    filtered = await self._apply_priority_filter(enriched)
+                    filtered = await self._filter_chain.apply(enriched)
                     self._cache_skipped_entries(enriched, filtered)
                     await self._enqueue_accepted_entries(filtered)
                 else:
@@ -66,15 +75,46 @@ class RSSPollWorker:
     # ── pipeline stages ──────────────────────────────────────────────
 
     def _detect_config_changes(self) -> None:
-        """Clear skip cache when priority config is modified at runtime."""
-        current = config.rss.priority
-        if current != self._last_priority:
+        """Rebuild filter chain and clear skip cache on config changes."""
+        current_priority = config.rss.priority
+        current_strict = config.rss.strict
+        current_rename_fmt = config.openlist.rename_format
+        current_filter_cfg = config.rss.filter
+
+        changed = False
+        if current_priority != self._last_priority:
             logger.info(
                 "Priority config changed, clearing skip cache "
                 f"({len(self._skip_cache)} entries)"
             )
+            changed = True
+        if current_strict != self._last_strict:
+            logger.info(f"Strict mode changed to {current_strict}")
+            changed = True
+        if current_rename_fmt != self._last_rename_format:
+            logger.info("Rename format changed")
+            changed = True
+        if current_filter_cfg != self._last_filter_cfg:
+            logger.info("Filter config changed")
+            changed = True
+
+        if changed:
             self._skip_cache.clear()
-            self._last_priority = current.model_copy(deep=True)
+            self._last_priority = current_priority.model_copy(deep=True)
+            self._last_strict = current_strict
+            self._last_rename_format = current_rename_fmt
+            self._last_filter_cfg = current_filter_cfg.model_copy(deep=True)
+            self._filter_chain = self._build_filter_chain()
+
+    def _build_filter_chain(self) -> FilterChain:
+        """Construct the filter chain based on current config."""
+        chain = FilterChain()
+        chain.add_filter(RegexTitleFilter())
+        chain.add_filter(MetadataFilter())
+        if config.rss.strict:
+            chain.add_filter(StrictRenameFilter())
+        chain.add_filter(PriorityFilter())
+        return chain
 
     async def _fetch_new_entries(self) -> list[AnimeResourceInfo]:
         """Fetch latest entries from all configured RSS feeds."""
@@ -102,12 +142,6 @@ class RSSPollWorker:
             if self._apply_metadata(entry, result):
                 enriched.append(entry)
         return enriched
-
-    async def _apply_priority_filter(
-        self, enriched: list[AnimeResourceInfo]
-    ) -> list[AnimeResourceInfo]:
-        """Keep only entries that are not dominated by already-downloaded resources."""
-        return await self._priority_filter.filter_batch(enriched)
 
     def _cache_skipped_entries(
         self,

--- a/src/openlist_ani/config.py
+++ b/src/openlist_ani/config.py
@@ -4,6 +4,8 @@ Supports hot-reloading and Pydantic validation.
 """
 
 import os
+import re
+import string
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -40,9 +42,32 @@ class PriorityConfig(BaseModel):
     )  # Quality priority (high to low); set to [] to disable
 
 
+class MetadataFilterConfig(BaseModel):
+    """Configuration for metadata-based blacklist filtering.
+
+    Each field is a list of values to exclude.  An RSS entry whose
+    metadata matches any value in the corresponding list is filtered out.
+    """
+
+    exclude_fansub: list[str] = Field(
+        default_factory=list
+    )  # Fansub groups to exclude, e.g. ["XX字幕组"]
+    exclude_quality: list[str] = Field(
+        default_factory=list
+    )  # Quality values to exclude, e.g. ["480p"]
+    exclude_languages: list[str] = Field(
+        default_factory=list
+    )  # Language values to exclude, e.g. ["未知"]
+    exclude_patterns: list[str] = Field(
+        default_factory=list
+    )  # Regex patterns to exclude RSS entries by title
+
+
 class RSSConfig(BaseModel):
     urls: list[str] = Field(default_factory=list)
     interval_time: int = 300  # RSS fetch interval in seconds (default: 5 minutes)
+    strict: bool = False  # Strict mode: filter entries whose rename stem matches existing downloads
+    filter: MetadataFilterConfig = MetadataFilterConfig()
     priority: PriorityConfig = PriorityConfig()
 
 
@@ -178,6 +203,12 @@ class UserConfig(BaseModel):
     backend: BackendConfig = BackendConfig()
 
 
+# Supported field names for ``rename_format`` in ``[openlist]``.
+_SUPPORTED_RENAME_FIELDS: frozenset[str] = frozenset(
+    {"anime_name", "season", "episode", "fansub", "quality", "languages"}
+)
+
+
 class ConfigManager:
     def __init__(self, config_path: str = "config.toml"):
         self.config_path = Path(os.getcwd()) / config_path
@@ -270,6 +301,8 @@ class ConfigManager:
         warnings: list[str] = []
 
         self._validate_core_config(errors)
+        self._validate_rename_format(errors)
+        self._validate_exclude_patterns(errors)
         self._validate_llm_config(errors)
         self._validate_notification_config(errors, warnings)
         self._validate_assistant_config(errors, warnings)
@@ -289,6 +322,43 @@ class ConfigManager:
                 "OpenList token is not configured in [openlist] token. "
                 "Authentication will fail without a valid token."
             )
+
+    def _validate_rename_format(self, errors: list[str]) -> None:
+        """Validate that ``rename_format`` uses only supported field names."""
+        fmt = self.openlist.rename_format
+        if not fmt:
+            return
+
+        formatter = string.Formatter()
+        try:
+            parsed_fields = {
+                field_name
+                for _, field_name, _, _ in formatter.parse(fmt)
+                if field_name is not None
+            }
+        except (ValueError, KeyError) as e:
+            errors.append(
+                f"Invalid rename_format syntax: '{fmt}'. Error: {e}"
+            )
+            return
+
+        unsupported = parsed_fields - _SUPPORTED_RENAME_FIELDS
+        if unsupported:
+            errors.append(
+                f"rename_format contains unsupported fields: {unsupported}. "
+                f"Supported fields: {sorted(_SUPPORTED_RENAME_FIELDS)}"
+            )
+
+    def _validate_exclude_patterns(self, errors: list[str]) -> None:
+        """Validate that ``exclude_patterns`` entries are valid regular expressions."""
+        for i, pattern in enumerate(self.rss.filter.exclude_patterns):
+            try:
+                re.compile(pattern)
+            except re.error as e:
+                errors.append(
+                    f"rss.filter.exclude_patterns[{i}] is not a valid regex: "
+                    f"'{pattern}'. Error: {e}"
+                )
 
     def _validate_llm_config(self, errors: list[str]) -> None:
         if not self.llm.openai_api_key:

--- a/src/openlist_ani/core/parser/llm/__init__.py
+++ b/src/openlist_ani/core/parser/llm/__init__.py
@@ -1,3 +1,3 @@
-from .client import LLMClient, OpenAILLMClient
+from .client import AnthropicLLMClient, LLMClient, OpenAILLMClient, create_llm_client
 
-__all__ = ["LLMClient", "OpenAILLMClient"]
+__all__ = ["AnthropicLLMClient", "LLMClient", "OpenAILLMClient", "create_llm_client"]

--- a/src/openlist_ani/core/parser/llm/client.py
+++ b/src/openlist_ani/core/parser/llm/client.py
@@ -1,9 +1,15 @@
-from abc import ABC, abstractmethod
-from typing import Any
+from __future__ import annotations
 
-from openai import AsyncOpenAI
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ....config import LLMConfig
 
 from ..constants import LLM_REQUEST_TIMEOUT
+
+# Default max_tokens for Anthropic messages API.
+_ANTHROPIC_DEFAULT_MAX_TOKENS = 8192
 
 
 class LLMClient(ABC):
@@ -21,6 +27,8 @@ class OpenAILLMClient(LLMClient):
         model: str,
         timeout: float = LLM_REQUEST_TIMEOUT,
     ) -> None:
+        from openai import AsyncOpenAI
+
         self._client = AsyncOpenAI(api_key=api_key, base_url=base_url, timeout=timeout)
         self._model = model
 
@@ -33,3 +41,80 @@ class OpenAILLMClient(LLMClient):
         }
         response = await self._client.chat.completions.create(**kwargs)
         return response.choices[0].message.content or ""
+
+
+class AnthropicLLMClient(LLMClient):
+    """LLM client using the Anthropic Messages API."""
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str,
+        model: str,
+        timeout: float = LLM_REQUEST_TIMEOUT,
+    ) -> None:
+        from anthropic import AsyncAnthropic
+
+        self._client = AsyncAnthropic(
+            api_key=api_key, base_url=base_url, timeout=timeout
+        )
+        self._model = model
+
+    async def complete_chat(
+        self, messages: list[dict[str, str]], model: str | None = None
+    ) -> str:
+        # Anthropic requires system messages as a separate parameter.
+        system_parts: list[str] = []
+        api_messages: list[dict[str, str]] = []
+        for msg in messages:
+            if msg.get("role") == "system":
+                system_parts.append(msg["content"])
+            else:
+                api_messages.append(msg)
+
+        kwargs: dict[str, Any] = {
+            "model": model or self._model,
+            "messages": api_messages,
+            "max_tokens": _ANTHROPIC_DEFAULT_MAX_TOKENS,
+        }
+        if system_parts:
+            kwargs["system"] = "\n\n".join(system_parts)
+
+        response = await self._client.messages.create(**kwargs)
+        # Filter out ThinkingBlock; only extract TextBlock content.
+        for block in response.content:
+            if block.type == "text":
+                return block.text
+        return ""
+
+
+def create_llm_client(llm_config: LLMConfig) -> LLMClient:
+    """Create an LLM client based on provider_type in config.
+
+    Args:
+        llm_config: LLM configuration from user config.
+
+    Returns:
+        An LLMClient instance for the configured provider.
+
+    Raises:
+        ValueError: If provider_type is not recognized.
+    """
+    match llm_config.provider_type:
+        case "openai":
+            return OpenAILLMClient(
+                api_key=llm_config.openai_api_key,
+                base_url=llm_config.openai_base_url,
+                model=llm_config.openai_model,
+            )
+        case "anthropic":
+            return AnthropicLLMClient(
+                api_key=llm_config.openai_api_key,
+                base_url=llm_config.openai_base_url,
+                model=llm_config.openai_model,
+            )
+        case _:
+            raise ValueError(
+                f"Unknown provider_type: '{llm_config.provider_type}'. "
+                "Supported values: 'openai', 'anthropic'."
+            )

--- a/src/openlist_ani/core/parser/parser.py
+++ b/src/openlist_ani/core/parser/parser.py
@@ -5,7 +5,7 @@ from ...logger import logger
 from ..website.model import AnimeResourceInfo
 from .constants import DEFAULT_BATCH_SIZE
 from .llm.batch_parser import parse_title_batch_via_llm
-from .llm.client import OpenAILLMClient
+from .llm.client import create_llm_client
 from .model import ParseResult
 from .tmdb.api import get_tmdb_client
 from .tmdb.resolver import TMDBResolver
@@ -52,11 +52,7 @@ async def _parse_misses(
     Returns:
         A list of ParseResult for every miss entry, in order.
     """
-    llm = OpenAILLMClient(
-        api_key=config.llm.openai_api_key,
-        base_url=config.llm.openai_base_url,
-        model=config.llm.openai_model,
-    )
+    llm = create_llm_client(config.llm)
     tmdb_client = get_tmdb_client()
     resolver = TMDBResolver(llm_client=llm, tmdb_client=tmdb_client)
 

--- a/src/openlist_ani/core/rss/__init__.py
+++ b/src/openlist_ani/core/rss/__init__.py
@@ -2,7 +2,20 @@
 RSS feed management package.
 """
 
+from .filter import (
+    FilterChain,
+    MetadataFilter,
+    PriorityFilter,
+    RegexTitleFilter,
+    StrictRenameFilter,
+)
 from .manager import RSSManager
-from .priority import ResourcePriorityFilter
 
-__all__ = ["RSSManager", "ResourcePriorityFilter"]
+__all__ = [
+    "FilterChain",
+    "MetadataFilter",
+    "PriorityFilter",
+    "RSSManager",
+    "RegexTitleFilter",
+    "StrictRenameFilter",
+]

--- a/src/openlist_ani/core/rss/filter/__init__.py
+++ b/src/openlist_ani/core/rss/filter/__init__.py
@@ -1,0 +1,30 @@
+"""
+RSS resource filter package.
+
+Provides a composable filter chain for RSS entry filtering:
+
+- ``ResourceFilter`` — protocol that all filters implement.
+- ``FilterChain`` — orchestrator that runs filters in sequence.
+- ``RegexTitleFilter`` — regex-based title exclusion filtering.
+- ``MetadataFilter`` — metadata-based blacklist filtering.
+- ``PriorityFilter`` — priority-based filtering (fansub/quality/language).
+- ``StrictRenameFilter`` — strict duplicate filtering based on rename output.
+"""
+
+from .base import EpisodeKey, FilterChain, ResourceFilter, group_by_episode
+from .metadata import MetadataFilter
+from .priority import PriorityFilter
+from .regex import RegexTitleFilter
+from .strict import StrictRenameFilter, compute_rename_stem
+
+__all__ = [
+    "EpisodeKey",
+    "FilterChain",
+    "MetadataFilter",
+    "PriorityFilter",
+    "RegexTitleFilter",
+    "ResourceFilter",
+    "StrictRenameFilter",
+    "compute_rename_stem",
+    "group_by_episode",
+]

--- a/src/openlist_ani/core/rss/filter/base.py
+++ b/src/openlist_ani/core/rss/filter/base.py
@@ -1,0 +1,101 @@
+"""
+Filter chain infrastructure for RSS resource filtering.
+
+Defines the ``ResourceFilter`` protocol and the ``FilterChain`` orchestrator
+that runs a sequence of filters in order.  Also provides shared helpers used
+by multiple filter implementations.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from ...website.model import AnimeResourceInfo
+
+# Type alias for the episode-level grouping key.
+EpisodeKey = tuple[str, int, int]  # (anime_name, season, episode)
+
+
+@runtime_checkable
+class ResourceFilter(Protocol):
+    """Protocol for RSS resource filters.
+
+    Each filter receives a list of candidates and returns the subset
+    that should proceed to the next stage.
+    """
+
+    async def apply(
+        self,
+        candidates: list[AnimeResourceInfo],
+    ) -> list[AnimeResourceInfo]:
+        """Filter *candidates* and return those that pass.
+
+        Args:
+            candidates: Parsed entries with metadata already populated.
+
+        Returns:
+            Entries that passed this filter.
+        """
+        ...
+
+
+class FilterChain:
+    """Execute a sequence of ``ResourceFilter`` instances in order.
+
+    Filters run in insertion order.  If any filter reduces the list to
+    empty, remaining filters are skipped (short-circuit).
+    """
+
+    def __init__(
+        self, filters: list[ResourceFilter] | None = None
+    ) -> None:
+        self._filters: list[ResourceFilter] = list(filters or [])
+
+    def add_filter(self, resource_filter: ResourceFilter) -> None:
+        """Append a filter to the end of the chain."""
+        self._filters.append(resource_filter)
+
+    async def apply(
+        self,
+        candidates: list[AnimeResourceInfo],
+    ) -> list[AnimeResourceInfo]:
+        """Run all filters in order, piping output to the next.
+
+        Args:
+            candidates: Initial list of entries.
+
+        Returns:
+            Entries that survived every filter in the chain.
+        """
+        result = candidates
+        for resource_filter in self._filters:
+            # Handle both sync and async filters
+            if hasattr(resource_filter.apply, '__call__'):
+                import inspect
+                if inspect.iscoroutinefunction(resource_filter.apply):
+                    result = await resource_filter.apply(result)
+                else:
+                    result = resource_filter.apply(result)
+            else:
+                result = await resource_filter.apply(result)
+            if not result:
+                break
+        return result
+
+
+def group_by_episode(
+    candidates: list[AnimeResourceInfo],
+) -> dict[EpisodeKey | None, list[AnimeResourceInfo]]:
+    """Group candidates by ``(anime_name, season, episode)``.
+
+    Entries missing any of the three fields go into the ``None`` group
+    and are typically left unfiltered (not enough metadata for decisions).
+    """
+    groups: dict[EpisodeKey | None, list[AnimeResourceInfo]] = {}
+    for c in candidates:
+        if c.anime_name is None or c.season is None or c.episode is None:
+            groups.setdefault(None, []).append(c)
+        else:
+            key: EpisodeKey = (c.anime_name, c.season, c.episode)
+            groups.setdefault(key, []).append(c)
+    return groups

--- a/src/openlist_ani/core/rss/filter/metadata.py
+++ b/src/openlist_ani/core/rss/filter/metadata.py
@@ -1,0 +1,91 @@
+"""
+Metadata-based blacklist filter.
+
+Filters out RSS entries whose LLM-parsed metadata (fansub, quality,
+languages) matches any value in the user-configured exclusion lists
+under ``[rss.filter]``.
+"""
+
+from __future__ import annotations
+
+from ....config import MetadataFilterConfig, config
+from ....logger import logger
+from ...website.model import AnimeResourceInfo
+
+
+class MetadataFilter:
+    """Filter candidates by metadata blacklists.
+
+    Config values are read from the hot-reloadable
+    ``config.rss.filter`` on every call to ``apply``,
+    so changes in *config.toml* take effect without a restart.
+    """
+
+    def apply(
+        self,
+        candidates: list[AnimeResourceInfo],
+    ) -> list[AnimeResourceInfo]:
+        """Return candidates not matching any metadata exclusion rule.
+
+        Args:
+            candidates: Parsed entries with metadata already populated.
+
+        Returns:
+            Entries that passed metadata filtering.
+        """
+        if not candidates:
+            return []
+
+        filter_cfg = config.rss.filter
+        if (
+            not filter_cfg.exclude_fansub
+            and not filter_cfg.exclude_quality
+            and not filter_cfg.exclude_languages
+        ):
+            return candidates
+
+        accepted: list[AnimeResourceInfo] = []
+        for candidate in candidates:
+            if self._is_excluded(candidate, filter_cfg):
+                logger.info(
+                    f"Metadata filter: excluding {candidate.title} "
+                    f"(matched metadata blacklist)"
+                )
+                continue
+            accepted.append(candidate)
+
+        skipped = len(candidates) - len(accepted)
+        if skipped:
+            logger.info(
+                f"Metadata filter: {len(accepted)} accepted, {skipped} excluded"
+            )
+        return accepted
+
+    @staticmethod
+    def _is_excluded(
+        candidate: AnimeResourceInfo,
+        filter_cfg: MetadataFilterConfig,
+    ) -> bool:
+        """Return True if *candidate* matches any exclusion rule."""
+        # Fansub: exact match
+        if (
+            filter_cfg.exclude_fansub
+            and candidate.fansub in filter_cfg.exclude_fansub
+        ):
+            return True
+
+        # Quality: match against .value string
+        if (
+            filter_cfg.exclude_quality
+            and candidate.quality
+            and candidate.quality.value in filter_cfg.exclude_quality
+        ):
+            return True
+
+        # Languages: any language in exclusion list
+        if filter_cfg.exclude_languages:
+            for lang in candidate.languages:
+                if lang.value in filter_cfg.exclude_languages:
+                    return True
+
+        return False

--- a/src/openlist_ani/core/rss/filter/priority.py
+++ b/src/openlist_ani/core/rss/filter/priority.py
@@ -16,26 +16,24 @@ All other fields default to no priority (everything passes).
 
 from __future__ import annotations
 
-from ...config import config
-from ...database import db
-from ...logger import logger
-from ..website.model import AnimeResourceInfo
-
-# Type alias for the episode-level grouping key.
-_EpisodeKey = tuple[str, int, int]  # (anime_name, season, episode)
+from ....config import config
+from ....database import db
+from ....logger import logger
+from ...website.model import AnimeResourceInfo
+from .base import EpisodeKey, group_by_episode
 
 
-class ResourcePriorityFilter:
+class PriorityFilter:
     """Filters a batch of parsed resources according to priority rules.
 
     Config values are read from the hot-reloadable ``config.priority``
-    on every call to ``filter_batch``, so changes in *config.toml*
+    on every call to ``apply``, so changes in *config.toml*
     take effect without a restart.
     """
 
     # ── public API ───────────────────────────────────────────────────
 
-    async def filter_batch(
+    async def apply(
         self,
         candidates: list[AnimeResourceInfo],
     ) -> list[AnimeResourceInfo]:
@@ -52,16 +50,16 @@ class ResourcePriorityFilter:
 
         priority_cfg = config.rss.priority
         fansub_list = priority_cfg.fansub
-        lang_list = priority_cfg.languages
+        language_list = priority_cfg.languages
         quality_list = priority_cfg.quality
         field_order = priority_cfg.field_order
 
         # Fast path: no priority rules at all → pass everything through.
-        if not fansub_list and not lang_list and not quality_list:
+        if not fansub_list and not language_list and not quality_list:
             return candidates
 
         # Group by (anime_name, season, episode).
-        groups = self._group_by_episode(candidates)
+        groups = group_by_episode(candidates)
         accepted: list[AnimeResourceInfo] = []
 
         for key, group in groups.items():
@@ -69,7 +67,7 @@ class ResourcePriorityFilter:
                 key,
                 group,
                 fansub_list,
-                lang_list,
+                language_list,
                 quality_list,
                 field_order,
             )
@@ -80,35 +78,14 @@ class ResourcePriorityFilter:
             logger.info(f"Priority filter: {len(accepted)} accepted, {skipped} skipped")
         return accepted
 
-    # ── grouping ─────────────────────────────────────────────────────
-
-    @staticmethod
-    def _group_by_episode(
-        candidates: list[AnimeResourceInfo],
-    ) -> dict[_EpisodeKey | None, list[AnimeResourceInfo]]:
-        """Group candidates by (anime_name, season, episode).
-
-        Entries missing any of the three fields are put into a ``None``
-        group and will bypass priority filtering entirely (not enough
-        metadata to make decisions).
-        """
-        groups: dict[_EpisodeKey | None, list[AnimeResourceInfo]] = {}
-        for c in candidates:
-            if c.anime_name is None or c.season is None or c.episode is None:
-                groups.setdefault(None, []).append(c)
-            else:
-                key: _EpisodeKey = (c.anime_name, c.season, c.episode)
-                groups.setdefault(key, []).append(c)
-        return groups
-
     # ── per-group filtering ──────────────────────────────────────────
 
     async def _filter_group(
         self,
-        key: _EpisodeKey | None,
+        key: EpisodeKey | None,
         group: list[AnimeResourceInfo],
         fansub_list: list[str],
-        lang_list: list[str],
+        language_list: list[str],
         quality_list: list[str],
         field_order: list[str],
     ) -> list[AnimeResourceInfo]:
@@ -136,7 +113,7 @@ class ResourcePriorityFilter:
                 candidate,
                 known,
                 fansub_list,
-                lang_list,
+                language_list,
                 quality_list,
                 field_order,
             ):
@@ -151,7 +128,7 @@ class ResourcePriorityFilter:
         # Batch-internal selection among the remaining candidates.
         if len(remaining) > 1:
             best = self._select_best_in_batch(
-                remaining, fansub_list, lang_list, quality_list, field_order
+                remaining, fansub_list, language_list, quality_list, field_order
             )
             accepted.extend(best)
         else:
@@ -188,7 +165,7 @@ class ResourcePriorityFilter:
         candidate: AnimeResourceInfo,
         downloaded: list[dict],
         fansub_list: list[str],
-        lang_list: list[str],
+        language_list: list[str],
         quality_list: list[str],
         field_order: list[str],
     ) -> bool:
@@ -209,7 +186,7 @@ class ResourcePriorityFilter:
                 candidate,
                 downloaded,
                 fansub_list,
-                lang_list,
+                language_list,
                 quality_list,
             )
             if cand_level is None and best_dl is None:
@@ -231,7 +208,7 @@ class ResourcePriorityFilter:
         candidate: AnimeResourceInfo,
         downloaded: list[dict],
         fansub_list: list[str],
-        lang_list: list[str],
+        language_list: list[str],
         quality_list: list[str],
     ) -> tuple[int | None, int | None]:
         """Return ``(candidate_level, best_downloaded_level)`` for *field*."""
@@ -252,9 +229,9 @@ class ResourcePriorityFilter:
             )
             return cand, best
 
-        if field == "languages" and lang_list:
-            cand = self._get_language_level(candidate, lang_list)
-            best = self._get_best_downloaded_language_level(downloaded, lang_list)
+        if field == "languages" and language_list:
+            cand = self._get_language_level(candidate, language_list)
+            best = self._get_best_downloaded_language_level(downloaded, language_list)
             return cand, best
 
         return None, None  # unknown or empty field → skip
@@ -264,29 +241,35 @@ class ResourcePriorityFilter:
     @staticmethod
     def _get_language_level(
         candidate: AnimeResourceInfo,
-        lang_list: list[str],
+        language_list: list[str],
     ) -> int | None:
-        """Return the best (lowest) priority index among the candidate's languages."""
-        best: int | None = None
-        for lang in candidate.languages:
-            idx = _index_or_none(lang.value, lang_list)
-            if idx is not None and (best is None or idx < best):
-                best = idx
-        return best
+        """Return the priority index for the candidate's language set.
+
+        The candidate's languages are joined into a sorted string
+        (e.g. ``[CHS, CHT]`` → ``"简繁"``).  Matching uses
+        ``_language_level``: exact match first, then single-character
+        contains fallback.
+        """
+        if not candidate.languages:
+            return None
+        lang_str = "".join(sorted(lang.value for lang in candidate.languages))
+        return _language_level(lang_str, language_list)
 
     @staticmethod
     def _get_best_downloaded_language_level(
         downloaded: list[dict],
-        lang_list: list[str],
+        language_list: list[str],
     ) -> int | None:
         """Return the best priority index among all downloaded language sets."""
         best: int | None = None
         for rec in downloaded:
             lang_str = rec["languages"] or ""
-            for ch in lang_str:
-                idx = _index_or_none(ch, lang_list)
-                if idx is not None and (best is None or idx < best):
-                    best = idx
+            if not lang_str:
+                continue
+            sorted_str = "".join(sorted(lang_str))
+            idx = _language_level(sorted_str, language_list)
+            if idx is not None and (best is None or idx < best):
+                best = idx
         return best
 
     # ── batch-internal lexicographic selection ──────────────────────
@@ -295,7 +278,7 @@ class ResourcePriorityFilter:
         self,
         candidates: list[AnimeResourceInfo],
         fansub_list: list[str],
-        lang_list: list[str],
+        language_list: list[str],
         quality_list: list[str],
         field_order: list[str],
     ) -> list[AnimeResourceInfo]:
@@ -307,7 +290,7 @@ class ResourcePriorityFilter:
         """
         levels = [
             self._compute_priority_levels(
-                c, fansub_list, lang_list, quality_list, field_order
+                c, fansub_list, language_list, quality_list, field_order
             )
             for c in candidates
         ]
@@ -325,7 +308,7 @@ class ResourcePriorityFilter:
         self,
         candidate: AnimeResourceInfo,
         fansub_list: list[str],
-        lang_list: list[str],
+        language_list: list[str],
         quality_list: list[str],
         field_order: list[str],
     ) -> tuple[int | None, ...]:
@@ -340,8 +323,8 @@ class ResourcePriorityFilter:
             elif field == "quality" and quality_list:
                 val = candidate.quality.value if candidate.quality else ""
                 levels.append(_index_or_none(val, quality_list))
-            elif field == "languages" and lang_list:
-                levels.append(self._get_language_level(candidate, lang_list))
+            elif field == "languages" and language_list:
+                levels.append(self._get_language_level(candidate, language_list))
         return tuple(levels)
 
 
@@ -354,6 +337,39 @@ def _index_or_none(value: str, lst: list[str]) -> int | None:
         return lst.index(value)
     except ValueError:
         return None
+
+
+def _language_level(lang_str: str, priority_list: list[str]) -> int | None:
+    """Return the priority index for a joined language string.
+
+    Matching strategy:
+
+    1. **Exact match**: look up the sorted *lang_str* directly in
+       *priority_list* (e.g. ``"简繁"`` matches ``"简繁"``).
+    2. **Contains fallback**: if no exact match, find the best
+       single-character entry in *priority_list* that appears in
+       *lang_str* (e.g. ``"简"`` is contained in ``"简繁"``).
+
+    Exact match always takes precedence.  This allows users to
+    configure ``["简", "简繁", "繁"]`` so that *pure CHS* has higher
+    priority than *CHS+CHT dual*.  Backward compatible: with
+    ``["简", "繁"]`` a dual ``"简繁"`` string still matches ``"简"``
+    via the contains fallback.
+    """
+    # Sort the lang_str and each entry for consistent comparison.
+    sorted_str = "".join(sorted(lang_str))
+
+    # Pass 1: exact match against sorted entries.
+    for i, entry in enumerate(priority_list):
+        if "".join(sorted(entry)) == sorted_str:
+            return i
+
+    # Pass 2: single-character contains fallback.
+    best: int | None = None
+    for i, entry in enumerate(priority_list):
+        if len(entry) == 1 and entry in sorted_str and (best is None or i < best):
+            best = i
+    return best
 
 
 def _best_field_level(values: list[str], priority_list: list[str]) -> int | None:

--- a/src/openlist_ani/core/rss/filter/regex.py
+++ b/src/openlist_ani/core/rss/filter/regex.py
@@ -1,0 +1,61 @@
+"""
+Regex-based title exclusion filter.
+
+Filters out RSS entries whose title matches any of the user-configured
+regular expression patterns in ``config.rss.filter.exclude_patterns``.
+"""
+
+from __future__ import annotations
+
+import re
+
+from ....config import config
+from ....logger import logger
+from ...website.model import AnimeResourceInfo
+
+
+class RegexTitleFilter:
+    """Filter candidates by matching their title against exclusion patterns.
+
+    Config values are read from the hot-reloadable
+    ``config.rss.filter.exclude_patterns`` on every call to ``apply``,
+    so changes in *config.toml* take effect without a restart.
+    """
+
+    def apply(
+        self,
+        candidates: list[AnimeResourceInfo],
+    ) -> list[AnimeResourceInfo]:
+        """Return candidates whose title does not match any exclusion pattern.
+
+        Args:
+            candidates: Parsed entries with title already populated.
+
+        Returns:
+            Entries that passed regex title filtering.
+        """
+        if not candidates:
+            return []
+
+        patterns = config.rss.filter.exclude_patterns
+        if not patterns:
+            return candidates
+
+        compiled = [re.compile(p) for p in patterns]
+        accepted: list[AnimeResourceInfo] = []
+
+        for candidate in candidates:
+            if any(r.search(candidate.title) for r in compiled):
+                logger.info(
+                    f"Regex filter: excluding {candidate.title} "
+                    f"(matched exclusion pattern)"
+                )
+                continue
+            accepted.append(candidate)
+
+        skipped = len(candidates) - len(accepted)
+        if skipped:
+            logger.info(
+                f"Regex filter: {len(accepted)} accepted, {skipped} excluded"
+            )
+        return accepted

--- a/src/openlist_ani/core/rss/filter/strict.py
+++ b/src/openlist_ani/core/rss/filter/strict.py
@@ -1,0 +1,223 @@
+"""
+Strict rename-based duplicate filter.
+
+When enabled via ``[rss] strict = true``, this filter computes the rename
+stem for each candidate entry and compares it against stems derived from
+already-downloaded records in the database.  Candidates whose stem matches
+an existing download are filtered out **unless** the candidate is a
+version upgrade.
+"""
+
+from __future__ import annotations
+
+from ....config import config
+from ....database import db
+from ....logger import logger
+from ...website.model import AnimeResourceInfo
+from .base import EpisodeKey, group_by_episode
+
+
+def compute_rename_stem(
+    rename_format: str,
+    anime_name: str,
+    season: int,
+    episode: int,
+    fansub: str | None = None,
+    quality: str | None = None,
+    languages: str = "",
+) -> str:
+    """Compute the rename stem from metadata and a format string.
+
+    Args:
+        rename_format: Python format string with named placeholders.
+        anime_name: Anime series name.
+        season: Season number.
+        episode: Episode number.
+        fansub: Fansub group name (or ``None``).
+        quality: Video quality string, e.g. ``"1080p"`` (or ``None``).
+        languages: Joined language string, e.g. ``"简繁"``.
+
+    Returns:
+        The formatted stem string, stripped of leading/trailing whitespace.
+        Falls back to ``"{anime_name} S{season:02d}E{episode:02d}"`` on
+        format errors.
+    """
+    context: dict[str, str | int] = {
+        "anime_name": anime_name or "",
+        "season": season or 0,
+        "episode": episode or 0,
+        "fansub": fansub or "",
+        "quality": quality or "",
+        "languages": languages or "",
+    }
+    try:
+        return rename_format.format(**context).strip()
+    except (KeyError, ValueError, IndexError):
+        name = anime_name or ""
+        s = season or 0
+        e = episode or 0
+        return f"{name} S{s:02d}E{e:02d}"
+
+
+def _stem_from_resource(
+    rename_format: str, resource: AnimeResourceInfo
+) -> str:
+    """Build a rename stem from an ``AnimeResourceInfo`` instance."""
+    quality_str = str(resource.quality) if resource.quality else ""
+    languages_str = "".join(str(lang) for lang in resource.languages)
+    return compute_rename_stem(
+        rename_format,
+        anime_name=resource.anime_name or "",
+        season=resource.season or 0,
+        episode=resource.episode or 0,
+        fansub=resource.fansub,
+        quality=quality_str,
+        languages=languages_str,
+    )
+
+
+def _stem_from_db_record(
+    rename_format: str,
+    anime_name: str,
+    season: int,
+    episode: int,
+    record: dict,
+) -> str:
+    """Build a rename stem from a database record dict."""
+    return compute_rename_stem(
+        rename_format,
+        anime_name=anime_name,
+        season=season,
+        episode=episode,
+        fansub=record.get("fansub"),
+        quality=record.get("quality"),
+        languages=record.get("languages", ""),
+    )
+
+
+class StrictRenameFilter:
+    """Filter candidates whose rename stem duplicates an existing download.
+
+    This filter reads ``config.openlist.rename_format`` on every call
+    (hot-reloadable) and compares each candidate's computed rename stem
+    against stems built from DB records of the same episode.
+
+    A candidate is **allowed through** if:
+
+    - Its stem does not match any existing download, OR
+    - It is a version upgrade (higher ``version`` than the matched record).
+
+    Within the same batch, if multiple candidates produce the same stem
+    only the one with the highest version is kept.
+    """
+
+    async def apply(
+        self,
+        candidates: list[AnimeResourceInfo],
+    ) -> list[AnimeResourceInfo]:
+        """Filter *candidates* by rename-stem deduplication.
+
+        Args:
+            candidates: Parsed entries with metadata already populated.
+
+        Returns:
+            Entries that passed strict rename filtering.
+        """
+        if not candidates:
+            return []
+
+        rename_format = config.openlist.rename_format
+
+        groups = group_by_episode(candidates)
+        accepted: list[AnimeResourceInfo] = []
+
+        for key, group in groups.items():
+            if key is None:
+                # Not enough metadata to compute a stem — bypass.
+                accepted.extend(group)
+                continue
+            filtered = await self._filter_group(rename_format, key, group)
+            accepted.extend(filtered)
+
+        skipped = len(candidates) - len(accepted)
+        if skipped:
+            logger.info(
+                f"Strict filter: {len(accepted)} accepted, {skipped} skipped"
+            )
+        return accepted
+
+    # ── per-group filtering ──────────────────────────────────────────
+
+    async def _filter_group(
+        self,
+        rename_format: str,
+        key: EpisodeKey,
+        group: list[AnimeResourceInfo],
+    ) -> list[AnimeResourceInfo]:
+        """Filter a single episode group against DB stems + intra-batch dedup."""
+        anime_name, season, episode = key
+
+        db_records = await db.find_resources_by_episode(
+            anime_name, season, episode
+        )
+        db_stems: list[tuple[str, int]] = [
+            (
+                _stem_from_db_record(
+                    rename_format, anime_name, season, episode, rec
+                ),
+                rec.get("version") or 1,
+            )
+            for rec in db_records
+        ]
+
+        # Phase 1: filter against DB records.
+        after_db: list[AnimeResourceInfo] = []
+        for candidate in group:
+            cand_stem = _stem_from_resource(rename_format, candidate)
+
+            if self._is_blocked_by_db(cand_stem, candidate.version, db_stems):
+                logger.info(
+                    f"Strict: skipping {candidate.title} "
+                    f"(rename stem matches existing download)"
+                )
+                continue
+            after_db.append(candidate)
+
+        # Phase 2: intra-batch dedup — same stem keeps highest version only.
+        return self._dedup_batch(rename_format, after_db)
+
+    # ── DB comparison ────────────────────────────────────────────────
+
+    @staticmethod
+    def _is_blocked_by_db(
+        candidate_stem: str,
+        candidate_version: int,
+        db_stems: list[tuple[str, int]],
+    ) -> bool:
+        """Return True if *candidate_stem* duplicates a DB entry.
+
+        The candidate is allowed through (returns ``False``) if its
+        version is strictly higher than the matching DB record.
+        """
+        for stem, version in db_stems:
+            if candidate_stem == stem:
+                if candidate_version > version:
+                    return False  # version upgrade → allow
+                return True  # same or lower version → block
+        return False
+
+    # ── intra-batch dedup ────────────────────────────────────────────
+
+    @staticmethod
+    def _dedup_batch(
+        rename_format: str,
+        candidates: list[AnimeResourceInfo],
+    ) -> list[AnimeResourceInfo]:
+        """Within a batch, keep only the highest-version entry per stem."""
+        stem_best: dict[str, AnimeResourceInfo] = {}
+        for c in candidates:
+            stem = _stem_from_resource(rename_format, c)
+            existing = stem_best.get(stem)
+            if existing is None or c.version > existing.version:
+                stem_best[stem] = c
+        return list(stem_best.values())

--- a/tests/assistant/test_auto_dream.py
+++ b/tests/assistant/test_auto_dream.py
@@ -141,7 +141,7 @@ class TestAutoDreamRunnerGates:
     @pytest.fixture
     def setup(self, tmp_path):
         """Create runner with minimal config and mock provider."""
-        from unittest.mock import AsyncMock
+        from unittest.mock import AsyncMock, MagicMock
 
         config = AutoDreamConfig(enabled=True, min_hours=24.0, min_sessions=2)
         provider = AsyncMock()
@@ -150,6 +150,7 @@ class TestAutoDreamRunnerGates:
                 "R", (), {"text": "Done", "tool_calls": [], "stop_reason": "stop", "usage": {}}
             )()
         )
+        provider.format_raw_tools = MagicMock(return_value=[])
 
         data_dir = tmp_path / "data"
         data_dir.mkdir()

--- a/tests/assistant/test_orchestrator.py
+++ b/tests/assistant/test_orchestrator.py
@@ -199,7 +199,7 @@ class TestToolOrchestrator:
             async def execute(self, **kwargs):
                 nonlocal call_count
                 call_count += 1
-                await asyncio.sleep(10)  # Very slow
+                await asyncio.sleep(0.01)  # Short sleep; enough for cancellation test
                 return "slow result"
 
         registry = ToolRegistry()

--- a/tests/assistant/test_session_storage.py
+++ b/tests/assistant/test_session_storage.py
@@ -208,11 +208,12 @@ class TestListSessions:
         await storage.record_message(Message(role=Role.USER, content="Hello"))
         await storage.record_message(Message(role=Role.ASSISTANT, content="Hi!"))
 
-        # Ensure s2 gets a strictly newer mtime.
-        # Filesystem mtime resolution is typically 1 second on Linux,
-        # so we must sleep long enough to guarantee ordering.
-        import asyncio
-        await asyncio.sleep(1.1)
+        # Backdate s1's file so s2 is strictly newer without a real sleep.
+        import os
+
+        s1_path = storage._sessions_dir / f"{s1}.jsonl"
+        old_time = time.time() - 10
+        os.utime(s1_path, (old_time, old_time))
 
         s2 = await storage.start_new_session()
         await storage.record_message(

--- a/tests/core/bangumi/test_bangumi.py
+++ b/tests/core/bangumi/test_bangumi.py
@@ -882,21 +882,20 @@ class TestBangumiClientThrottle:
 
     async def test_throttle_delays_rapid_calls(self):
         """Rapid successive _throttle calls should enforce minimum interval."""
-        client = BangumiClient(access_token="test")
+        from unittest.mock import AsyncMock, patch
 
-        loop = asyncio.get_event_loop()
+        client = BangumiClient(access_token="test")
 
         # First call — no delay expected
         await client._throttle()
-        first_done = loop.time()
 
-        # Second call — should sleep for approximately _REQUEST_INTERVAL
-        await client._throttle()
-        second_done = loop.time()
-
-        elapsed_between = second_done - first_done
-        # The second call should have waited at least close to _REQUEST_INTERVAL
-        assert elapsed_between >= _REQUEST_INTERVAL * 0.8
+        # Second call — should attempt to sleep for approximately _REQUEST_INTERVAL
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await client._throttle()
+            mock_sleep.assert_called_once()
+            delay = mock_sleep.call_args[0][0]
+            assert delay >= _REQUEST_INTERVAL * 0.5
+            assert delay <= _REQUEST_INTERVAL
 
     async def test_throttle_no_delay_after_interval(self):
         """No delay when enough time has passed since the last request."""

--- a/tests/core/parser/test_batch_parser.py
+++ b/tests/core/parser/test_batch_parser.py
@@ -200,7 +200,7 @@ class TestParseMetadataBatch:
             ),
             patch("openlist_ani.core.parser.parser.TMDBResolver") as MockResolver,
             patch("openlist_ani.core.parser.parser.get_tmdb_client"),
-            patch("openlist_ani.core.parser.parser.OpenAILLMClient"),
+            patch("openlist_ani.core.parser.parser.create_llm_client"),
         ):
             mock_config.llm.openai_api_key = "test-key"
             mock_config.llm.openai_base_url = "https://api.example.com"
@@ -233,7 +233,7 @@ class TestParseMetadataBatch:
             ),
             patch("openlist_ani.core.parser.parser.TMDBResolver") as MockResolver,
             patch("openlist_ani.core.parser.parser.get_tmdb_client"),
-            patch("openlist_ani.core.parser.parser.OpenAILLMClient"),
+            patch("openlist_ani.core.parser.parser.create_llm_client"),
         ):
             mock_config.llm.openai_api_key = "test-key"
             mock_config.llm.openai_base_url = "https://api.example.com"
@@ -280,7 +280,7 @@ class TestParseMetadataBatch:
             ),
             patch("openlist_ani.core.parser.parser.TMDBResolver") as MockResolver,
             patch("openlist_ani.core.parser.parser.get_tmdb_client"),
-            patch("openlist_ani.core.parser.parser.OpenAILLMClient"),
+            patch("openlist_ani.core.parser.parser.create_llm_client"),
         ):
             mock_config.llm.openai_api_key = "test-key"
             mock_config.llm.openai_base_url = "https://api.example.com"

--- a/tests/core/parser/test_parser.py
+++ b/tests/core/parser/test_parser.py
@@ -56,7 +56,7 @@ class TestParseMetadata:
                 "openlist_ani.core.parser.parser.TMDBResolver",
             ) as MockResolver,
             patch("openlist_ani.core.parser.parser.get_tmdb_client"),
-            patch("openlist_ani.core.parser.parser.OpenAILLMClient"),
+            patch("openlist_ani.core.parser.parser.create_llm_client"),
         ):
             mock_config.llm.openai_api_key = "test-key"
             mock_config.llm.openai_base_url = "https://api.example.com"
@@ -94,7 +94,7 @@ class TestParseMetadata:
                 "openlist_ani.core.parser.parser.TMDBResolver",
             ) as MockResolver,
             patch("openlist_ani.core.parser.parser.get_tmdb_client"),
-            patch("openlist_ani.core.parser.parser.OpenAILLMClient"),
+            patch("openlist_ani.core.parser.parser.create_llm_client"),
         ):
             mock_config.llm.openai_api_key = "test-key"
             mock_config.llm.openai_base_url = "https://api.example.com"
@@ -126,7 +126,7 @@ class TestParseMetadata:
                 "openlist_ani.core.parser.parser.TMDBResolver",
             ) as MockResolver,
             patch("openlist_ani.core.parser.parser.get_tmdb_client"),
-            patch("openlist_ani.core.parser.parser.OpenAILLMClient"),
+            patch("openlist_ani.core.parser.parser.create_llm_client"),
         ):
             mock_config.llm.openai_api_key = "test-key"
             mock_config.llm.openai_base_url = "https://api.example.com"
@@ -159,7 +159,7 @@ class TestParseMetadata:
                 "openlist_ani.core.parser.parser.TMDBResolver",
             ) as MockResolver,
             patch("openlist_ani.core.parser.parser.get_tmdb_client"),
-            patch("openlist_ani.core.parser.parser.OpenAILLMClient"),
+            patch("openlist_ani.core.parser.parser.create_llm_client"),
         ):
             mock_config.llm.openai_api_key = "test-key"
             mock_config.llm.openai_base_url = "https://api.example.com"
@@ -195,7 +195,7 @@ class TestParseMetadata:
                 "openlist_ani.core.parser.parser.TMDBResolver",
             ) as MockResolver,
             patch("openlist_ani.core.parser.parser.get_tmdb_client"),
-            patch("openlist_ani.core.parser.parser.OpenAILLMClient"),
+            patch("openlist_ani.core.parser.parser.create_llm_client"),
         ):
             mock_config.llm.openai_api_key = "test-key"
             mock_config.llm.openai_base_url = "https://api.example.com"
@@ -231,7 +231,7 @@ class TestParseMetadata:
                 "openlist_ani.core.parser.parser.TMDBResolver",
             ) as MockResolver,
             patch("openlist_ani.core.parser.parser.get_tmdb_client"),
-            patch("openlist_ani.core.parser.parser.OpenAILLMClient"),
+            patch("openlist_ani.core.parser.parser.create_llm_client"),
         ):
             mock_config.llm.openai_api_key = "test-key"
             mock_config.llm.openai_base_url = "https://api.example.com"
@@ -273,7 +273,7 @@ class TestParseMetadata:
                 "openlist_ani.core.parser.parser.TMDBResolver",
             ) as MockResolver,
             patch("openlist_ani.core.parser.parser.get_tmdb_client"),
-            patch("openlist_ani.core.parser.parser.OpenAILLMClient"),
+            patch("openlist_ani.core.parser.parser.create_llm_client"),
         ):
             mock_config.llm.openai_api_key = "test-key"
             mock_config.llm.openai_base_url = "https://api.example.com"
@@ -326,7 +326,7 @@ class TestParseMetadata:
                 "openlist_ani.core.parser.parser.TMDBResolver",
             ) as MockResolver,
             patch("openlist_ani.core.parser.parser.get_tmdb_client"),
-            patch("openlist_ani.core.parser.parser.OpenAILLMClient"),
+            patch("openlist_ani.core.parser.parser.create_llm_client"),
         ):
             mock_config.llm.openai_api_key = "test-key"
             mock_config.llm.openai_base_url = "https://api.example.com"
@@ -369,7 +369,7 @@ class TestParseMetadata:
                 "openlist_ani.core.parser.parser.TMDBResolver",
             ) as MockResolver,
             patch("openlist_ani.core.parser.parser.get_tmdb_client"),
-            patch("openlist_ani.core.parser.parser.OpenAILLMClient"),
+            patch("openlist_ani.core.parser.parser.create_llm_client"),
         ):
             mock_config.llm.openai_api_key = "test-key"
             mock_config.llm.openai_base_url = "https://api.example.com"

--- a/tests/core/rss/filter/test_base.py
+++ b/tests/core/rss/filter/test_base.py
@@ -1,0 +1,91 @@
+"""Tests for FilterChain orchestrator."""
+
+from __future__ import annotations
+
+from openlist_ani.core.rss.filter.base import FilterChain
+from openlist_ani.core.website.model import AnimeResourceInfo
+
+
+def _make_resource(title: str = "test") -> AnimeResourceInfo:
+    return AnimeResourceInfo(title=title, download_url="magnet:?xt=urn:btih:abc")
+
+
+class _PassAllFilter:
+    """Filter that passes everything through."""
+
+    def apply(
+        self, candidates: list[AnimeResourceInfo]
+    ) -> list[AnimeResourceInfo]:
+        return candidates
+
+
+class _DropAllFilter:
+    """Filter that drops everything."""
+
+    def apply(
+        self, candidates: list[AnimeResourceInfo]
+    ) -> list[AnimeResourceInfo]:
+        return []
+
+
+class _KeepFirstFilter:
+    """Filter that keeps only the first candidate."""
+
+    def apply(
+        self, candidates: list[AnimeResourceInfo]
+    ) -> list[AnimeResourceInfo]:
+        return candidates[:1] if candidates else []
+
+
+class TestFilterChain:
+    async def test_empty_chain_passes_all(self):
+        """An empty chain should pass all candidates through."""
+        chain = FilterChain()
+        entries = [_make_resource("a"), _make_resource("b")]
+        result = await chain.apply(entries)
+        assert len(result) == 2
+
+    async def test_single_filter_applied(self):
+        """A chain with one filter should apply that filter."""
+        chain = FilterChain([_KeepFirstFilter()])
+        entries = [_make_resource("a"), _make_resource("b")]
+        result = await chain.apply(entries)
+        assert len(result) == 1
+        assert result[0].title == "a"
+
+    async def test_multiple_filters_in_order(self):
+        """Filters should execute in insertion order."""
+        chain = FilterChain()
+        chain.add_filter(_PassAllFilter())
+        chain.add_filter(_KeepFirstFilter())
+        entries = [_make_resource("a"), _make_resource("b"), _make_resource("c")]
+        result = await chain.apply(entries)
+        assert len(result) == 1
+        assert result[0].title == "a"
+
+    async def test_short_circuit_on_empty(self):
+        """If a filter returns empty, subsequent filters are skipped."""
+        call_count = 0
+
+        class _CountingFilter:
+            def apply(
+                self, candidates: list[AnimeResourceInfo]
+            ) -> list[AnimeResourceInfo]:
+                nonlocal call_count
+                call_count += 1
+                return candidates
+
+        chain = FilterChain()
+        chain.add_filter(_DropAllFilter())
+        chain.add_filter(_CountingFilter())
+
+        entries = [_make_resource("a")]
+        result = await chain.apply(entries)
+        assert result == []
+        assert call_count == 0  # second filter never called
+
+    async def test_empty_input(self):
+        """Empty input should pass through without issues."""
+        chain = FilterChain([_PassAllFilter()])
+        result = await chain.apply([])
+        assert result == []

--- a/tests/core/rss/filter/test_metadata.py
+++ b/tests/core/rss/filter/test_metadata.py
@@ -1,0 +1,206 @@
+"""Tests for MetadataFilter."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from openlist_ani.core.rss.filter.metadata import MetadataFilter
+from openlist_ani.core.website.model import (
+    AnimeResourceInfo,
+    LanguageType,
+    VideoQuality,
+)
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+_CFG = "openlist_ani.core.rss.filter.metadata.config"
+
+
+def _make_resource(
+    title: str = "Test Anime - 01",
+    fansub: str | None = None,
+    quality: VideoQuality | None = VideoQuality.Q1080P,
+    languages: list[LanguageType] | None = None,
+) -> AnimeResourceInfo:
+    return AnimeResourceInfo(
+        title=title,
+        download_url="magnet:?xt=urn:btih:abc",
+        fansub=fansub,
+        quality=quality,
+        languages=languages or [],
+    )
+
+
+def _mock_config(
+    exclude_fansub: list[str] | None = None,
+    exclude_quality: list[str] | None = None,
+    exclude_languages: list[str] | None = None,
+):
+    """Return a mock config with the given filter settings."""
+    filter_cfg = SimpleNamespace(
+        exclude_fansub=exclude_fansub or [],
+        exclude_quality=exclude_quality or [],
+        exclude_languages=exclude_languages or [],
+    )
+    rss = SimpleNamespace(filter=filter_cfg)
+    return SimpleNamespace(rss=rss)
+
+
+# ── tests ────────────────────────────────────────────────────────────
+
+
+class TestMetadataFilter:
+    @pytest.mark.asyncio
+    async def test_empty_config_passes_all(self):
+        """No exclusion rules → everything passes."""
+        f = MetadataFilter()
+        candidates = [_make_resource("A"), _make_resource("B")]
+        with patch(_CFG, _mock_config()):
+            result = f.apply(candidates)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_batch(self):
+        """Empty batch returns empty list."""
+        f = MetadataFilter()
+        result = f.apply([])
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_exclude_fansub(self):
+        """Entries with excluded fansub should be filtered out."""
+        f = MetadataFilter()
+        candidates = [
+            _make_resource("A", fansub="BadSub"),
+            _make_resource("B", fansub="GoodSub"),
+            _make_resource("C", fansub=None),
+        ]
+        with patch(_CFG, _mock_config(exclude_fansub=["BadSub"])):
+            result = f.apply(candidates)
+        assert len(result) == 2
+        fansubs = {r.fansub for r in result}
+        assert "BadSub" not in fansubs
+
+    @pytest.mark.asyncio
+    async def test_exclude_multiple_fansubs(self):
+        """Multiple fansubs in exclusion list."""
+        f = MetadataFilter()
+        candidates = [
+            _make_resource("A", fansub="Sub_A"),
+            _make_resource("B", fansub="Sub_B"),
+            _make_resource("C", fansub="Sub_C"),
+        ]
+        with patch(_CFG, _mock_config(exclude_fansub=["Sub_A", "Sub_B"])):
+            result = f.apply(candidates)
+        assert len(result) == 1
+        assert result[0].fansub == "Sub_C"
+
+    @pytest.mark.asyncio
+    async def test_exclude_quality(self):
+        """Entries with excluded quality should be filtered out."""
+        f = MetadataFilter()
+        candidates = [
+            _make_resource("A", quality=VideoQuality.Q480P),
+            _make_resource("B", quality=VideoQuality.Q1080P),
+        ]
+        with patch(_CFG, _mock_config(exclude_quality=["480p"])):
+            result = f.apply(candidates)
+        assert len(result) == 1
+        assert result[0].quality == VideoQuality.Q1080P
+
+    @pytest.mark.asyncio
+    async def test_exclude_quality_unknown(self):
+        """Entries with UNKNOWN quality should be excludable."""
+        f = MetadataFilter()
+        candidates = [
+            _make_resource("A", quality=VideoQuality.UNKNOWN),
+            _make_resource("B", quality=VideoQuality.Q1080P),
+        ]
+        with patch(_CFG, _mock_config(exclude_quality=["unknown"])):
+            result = f.apply(candidates)
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_exclude_quality_none_not_excluded(self):
+        """Entry with quality=None should not be excluded by quality filter."""
+        f = MetadataFilter()
+        candidates = [_make_resource("A", quality=None)]
+        with patch(_CFG, _mock_config(exclude_quality=["480p"])):
+            result = f.apply(candidates)
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_exclude_languages(self):
+        """Entries with any excluded language should be filtered out."""
+        f = MetadataFilter()
+        candidates = [
+            _make_resource(
+                "A", languages=[LanguageType.CHS, LanguageType.CHT]
+            ),
+            _make_resource("B", languages=[LanguageType.JP]),
+            _make_resource("C", languages=[LanguageType.UNKNOWN]),
+        ]
+        with patch(_CFG, _mock_config(exclude_languages=["未知"])):
+            result = f.apply(candidates)
+        assert len(result) == 2
+        titles = {r.title for r in result}
+        assert "C" not in titles
+
+    @pytest.mark.asyncio
+    async def test_exclude_language_any_match(self):
+        """If any of candidate's languages matches exclusion, it's excluded."""
+        f = MetadataFilter()
+        candidates = [
+            _make_resource(
+                "A", languages=[LanguageType.CHS, LanguageType.UNKNOWN]
+            ),
+        ]
+        with patch(_CFG, _mock_config(exclude_languages=["未知"])):
+            result = f.apply(candidates)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_combined_exclusion_rules(self):
+        """Multiple exclusion types can work together."""
+        f = MetadataFilter()
+        candidates = [
+            _make_resource("A", fansub="BadSub", quality=VideoQuality.Q1080P),
+            _make_resource("B", fansub="GoodSub", quality=VideoQuality.Q480P),
+            _make_resource(
+                "C",
+                fansub="GoodSub",
+                quality=VideoQuality.Q1080P,
+                languages=[LanguageType.CHS],
+            ),
+        ]
+        with patch(
+            _CFG,
+            _mock_config(
+                exclude_fansub=["BadSub"],
+                exclude_quality=["480p"],
+            ),
+        ):
+            result = f.apply(candidates)
+        assert len(result) == 1
+        assert result[0].title == "C"
+
+    @pytest.mark.asyncio
+    async def test_empty_languages_not_excluded(self):
+        """Entry with no languages should not be excluded by language filter."""
+        f = MetadataFilter()
+        candidates = [_make_resource("A", languages=[])]
+        with patch(_CFG, _mock_config(exclude_languages=["未知"])):
+            result = f.apply(candidates)
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_none_fansub_not_excluded(self):
+        """Entry with fansub=None should not match a string exclusion."""
+        f = MetadataFilter()
+        candidates = [_make_resource("A", fansub=None)]
+        with patch(_CFG, _mock_config(exclude_fansub=["SomeSub"])):
+            result = f.apply(candidates)
+        assert len(result) == 1

--- a/tests/core/rss/filter/test_regex.py
+++ b/tests/core/rss/filter/test_regex.py
@@ -1,0 +1,135 @@
+"""Tests for RegexTitleFilter."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from openlist_ani.core.rss.filter.regex import RegexTitleFilter
+from openlist_ani.core.website.model import AnimeResourceInfo
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+_CFG = "openlist_ani.core.rss.filter.regex.config"
+
+
+def _make_resource(title: str = "Test Anime - 01") -> AnimeResourceInfo:
+    return AnimeResourceInfo(title=title, download_url="magnet:?xt=urn:btih:abc")
+
+
+def _mock_config(exclude_patterns: list[str] | None = None):
+    """Return a mock config with the given exclude_patterns."""
+    filter_cfg = SimpleNamespace(exclude_patterns=exclude_patterns or [])
+    rss = SimpleNamespace(filter=filter_cfg)
+    return SimpleNamespace(rss=rss)
+
+
+# ── tests ────────────────────────────────────────────────────────────
+
+
+class TestRegexTitleFilter:
+    @pytest.mark.asyncio
+    async def test_empty_patterns_passes_all(self):
+        """No patterns configured → everything passes."""
+        f = RegexTitleFilter()
+        candidates = [_make_resource("A"), _make_resource("B")]
+        with patch(_CFG, _mock_config([])):
+            result = f.apply(candidates)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_batch(self):
+        """Empty batch returns empty list."""
+        f = RegexTitleFilter()
+        result = f.apply([])
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_matching_pattern_excludes(self):
+        """Entry matching a pattern should be excluded."""
+        f = RegexTitleFilter()
+        candidates = [
+            _make_resource("[字幕组] 动漫 合集 01-12"),
+            _make_resource("[字幕组] 动漫 - 01"),
+        ]
+        with patch(_CFG, _mock_config(["合集"])):
+            result = f.apply(candidates)
+        assert len(result) == 1
+        assert result[0].title == "[字幕组] 动漫 - 01"
+
+    @pytest.mark.asyncio
+    async def test_multiple_patterns(self):
+        """Multiple patterns: any match excludes the entry."""
+        f = RegexTitleFilter()
+        candidates = [
+            _make_resource("Anime - SP01"),
+            _make_resource("Anime - 01 HEVC"),
+            _make_resource("Anime - 01"),
+        ]
+        with patch(_CFG, _mock_config(["SP\\d+", "HEVC"])):
+            result = f.apply(candidates)
+        assert len(result) == 1
+        assert result[0].title == "Anime - 01"
+
+    @pytest.mark.asyncio
+    async def test_regex_search_not_fullmatch(self):
+        """Pattern uses search (partial match), not fullmatch."""
+        f = RegexTitleFilter()
+        candidates = [_make_resource("Anime 720p x264 - 01")]
+        with patch(_CFG, _mock_config(["720p"])):
+            result = f.apply(candidates)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_no_match_passes_through(self):
+        """Entries not matching any pattern should pass."""
+        f = RegexTitleFilter()
+        candidates = [
+            _make_resource("Good Anime - 01"),
+            _make_resource("Good Anime - 02"),
+        ]
+        with patch(_CFG, _mock_config(["合集", "SP\\d+"])):
+            result = f.apply(candidates)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_case_sensitive_by_default(self):
+        """Regex matching should be case-sensitive by default."""
+        f = RegexTitleFilter()
+        candidates = [
+            _make_resource("Anime HEVC - 01"),
+            _make_resource("Anime hevc - 01"),
+        ]
+        with patch(_CFG, _mock_config(["HEVC"])):
+            result = f.apply(candidates)
+        assert len(result) == 1
+        assert result[0].title == "Anime hevc - 01"
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_with_flag(self):
+        """User can use (?i) in pattern for case-insensitive matching."""
+        f = RegexTitleFilter()
+        candidates = [
+            _make_resource("Anime HEVC - 01"),
+            _make_resource("Anime hevc - 01"),
+        ]
+        with patch(_CFG, _mock_config(["(?i)hevc"])):
+            result = f.apply(candidates)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_complex_regex(self):
+        """Complex regex patterns should work."""
+        f = RegexTitleFilter()
+        candidates = [
+            _make_resource("[Fansub] Anime - 01 [1080p]"),
+            _make_resource("[Fansub] Anime - 01 [480p]"),
+            _make_resource("[Fansub] Anime - 01 [720p]"),
+        ]
+        with patch(_CFG, _mock_config(["\\[480p\\]"])):
+            result = f.apply(candidates)
+        assert len(result) == 2
+        titles = {r.title for r in result}
+        assert "[Fansub] Anime - 01 [480p]" not in titles

--- a/tests/core/rss/filter/test_strict.py
+++ b/tests/core/rss/filter/test_strict.py
@@ -1,0 +1,350 @@
+"""Tests for StrictRenameFilter and compute_rename_stem."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from openlist_ani.core.rss.filter.strict import (
+    StrictRenameFilter,
+    compute_rename_stem,
+)
+from openlist_ani.core.website.model import (
+    AnimeResourceInfo,
+    LanguageType,
+    VideoQuality,
+)
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+_DEFAULT_FMT = (
+    "{anime_name} S{season:02d}E{episode:02d} {fansub} {quality} {languages}"
+)
+
+_DB_FIND = "openlist_ani.core.rss.filter.strict.db.find_resources_by_episode"
+_CFG = "openlist_ani.core.rss.filter.strict.config"
+
+
+def _make_resource(
+    title: str = "resource",
+    url: str = "magnet:?xt=urn:btih:abc",
+    anime_name: str = "TestAnime",
+    season: int = 1,
+    episode: int = 1,
+    fansub: str | None = None,
+    quality: VideoQuality = VideoQuality.Q1080P,
+    languages: list[LanguageType] | None = None,
+    version: int = 1,
+) -> AnimeResourceInfo:
+    return AnimeResourceInfo(
+        title=title,
+        download_url=url,
+        anime_name=anime_name,
+        season=season,
+        episode=episode,
+        fansub=fansub,
+        quality=quality,
+        languages=languages or [],
+        version=version,
+    )
+
+
+def _make_db_record(
+    fansub: str | None = None,
+    quality: str | None = "1080p",
+    languages: str = "",
+    version: int = 1,
+) -> dict:
+    return {
+        "fansub": fansub,
+        "quality": quality,
+        "languages": languages,
+        "version": version,
+    }
+
+
+def _mock_config(rename_format: str = _DEFAULT_FMT):
+    """Return a mock config with the given rename_format."""
+    from types import SimpleNamespace
+
+    openlist = SimpleNamespace(rename_format=rename_format)
+    return SimpleNamespace(openlist=openlist)
+
+
+# ── compute_rename_stem unit tests ──────────────────────────────────
+
+
+class TestComputeRenameStem:
+    def test_basic_format(self):
+        stem = compute_rename_stem(
+            _DEFAULT_FMT,
+            anime_name="进击的巨人",
+            season=1,
+            episode=5,
+            fansub="Fansub_A",
+            quality="1080p",
+            languages="简繁",
+        )
+        assert stem == "进击的巨人 S01E05 Fansub_A 1080p 简繁"
+
+    def test_none_values_become_empty(self):
+        stem = compute_rename_stem(
+            _DEFAULT_FMT,
+            anime_name="Test",
+            season=1,
+            episode=1,
+            fansub=None,
+            quality=None,
+            languages="",
+        )
+        assert "None" not in stem
+        assert "Test S01E01" in stem
+
+    def test_format_error_fallback(self):
+        """Invalid format string should fallback gracefully."""
+        stem = compute_rename_stem(
+            "{anime_name} {nonexistent_field}",
+            anime_name="Test",
+            season=1,
+            episode=2,
+        )
+        assert stem == "Test S01E02"
+
+    def test_strip_whitespace(self):
+        stem = compute_rename_stem(
+            "{anime_name} {fansub}",
+            anime_name="Test",
+            season=1,
+            episode=1,
+            fansub=None,
+        )
+        # Should be stripped, not "Test "
+        assert stem == "Test"
+
+    def test_custom_format(self):
+        stem = compute_rename_stem(
+            "{anime_name} E{episode:02d}",
+            anime_name="Anime",
+            season=1,
+            episode=3,
+        )
+        assert stem == "Anime E03"
+
+
+# ── StrictRenameFilter tests ────────────────────────────────────────
+
+
+class TestStrictRenameFilter:
+    @pytest.mark.asyncio
+    async def test_matching_stem_filtered(self):
+        """Entry whose stem matches a DB record should be filtered out."""
+        f = StrictRenameFilter()
+        candidates = [
+            _make_resource(
+                title="entry-1",
+                fansub="Fansub_A",
+                quality=VideoQuality.Q1080P,
+            ),
+        ]
+        db_records = [_make_db_record(fansub="Fansub_A", quality="1080p")]
+
+        with (
+            patch(_DB_FIND, new_callable=AsyncMock, return_value=db_records),
+            patch(_CFG, _mock_config()),
+        ):
+            result = await f.apply(candidates)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_no_matching_stem_passes(self):
+        """Entry whose stem differs from DB records should pass."""
+        f = StrictRenameFilter()
+        candidates = [
+            _make_resource(
+                title="entry-1",
+                fansub="Fansub_B",
+                quality=VideoQuality.Q720P,
+            ),
+        ]
+        db_records = [_make_db_record(fansub="Fansub_A", quality="1080p")]
+
+        with (
+            patch(_DB_FIND, new_callable=AsyncMock, return_value=db_records),
+            patch(_CFG, _mock_config()),
+        ):
+            result = await f.apply(candidates)
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_version_upgrade_bypass(self):
+        """Higher version should bypass strict filter even with matching stem."""
+        f = StrictRenameFilter()
+        candidates = [
+            _make_resource(
+                title="entry-v2",
+                fansub="Fansub_A",
+                quality=VideoQuality.Q1080P,
+                version=2,
+            ),
+        ]
+        db_records = [
+            _make_db_record(fansub="Fansub_A", quality="1080p", version=1)
+        ]
+
+        with (
+            patch(_DB_FIND, new_callable=AsyncMock, return_value=db_records),
+            patch(_CFG, _mock_config()),
+        ):
+            result = await f.apply(candidates)
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_same_version_blocked(self):
+        """Same version with matching stem should be blocked."""
+        f = StrictRenameFilter()
+        candidates = [
+            _make_resource(
+                title="entry-dup",
+                fansub="Fansub_A",
+                quality=VideoQuality.Q1080P,
+                version=1,
+            ),
+        ]
+        db_records = [
+            _make_db_record(fansub="Fansub_A", quality="1080p", version=1)
+        ]
+
+        with (
+            patch(_DB_FIND, new_callable=AsyncMock, return_value=db_records),
+            patch(_CFG, _mock_config()),
+        ):
+            result = await f.apply(candidates)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_missing_metadata_bypasses(self):
+        """Entries without anime_name/season/episode bypass strict filter."""
+        f = StrictRenameFilter()
+        candidates = [_make_resource(title="no-meta")]
+        candidates[0].anime_name = None
+
+        with patch(_CFG, _mock_config()):
+            result = await f.apply(candidates)
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_db_records_passes(self):
+        """If no existing downloads for the episode, entry passes."""
+        f = StrictRenameFilter()
+        candidates = [
+            _make_resource(title="new-entry", fansub="Fansub_A"),
+        ]
+
+        with (
+            patch(_DB_FIND, new_callable=AsyncMock, return_value=[]),
+            patch(_CFG, _mock_config()),
+        ):
+            result = await f.apply(candidates)
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_batch(self):
+        """Empty batch returns empty list."""
+        f = StrictRenameFilter()
+        result = await f.apply([])
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_intra_batch_dedup_keeps_highest_version(self):
+        """Within a batch, same stem keeps only the highest version."""
+        f = StrictRenameFilter()
+        candidates = [
+            _make_resource(
+                title="entry-v1",
+                fansub="Fansub_A",
+                quality=VideoQuality.Q1080P,
+                version=1,
+                url="magnet:v1",
+            ),
+            _make_resource(
+                title="entry-v2",
+                fansub="Fansub_A",
+                quality=VideoQuality.Q1080P,
+                version=2,
+                url="magnet:v2",
+            ),
+        ]
+
+        with (
+            patch(_DB_FIND, new_callable=AsyncMock, return_value=[]),
+            patch(_CFG, _mock_config()),
+        ):
+            result = await f.apply(candidates)
+        assert len(result) == 1
+        assert result[0].title == "entry-v2"
+
+    @pytest.mark.asyncio
+    async def test_different_stems_both_pass(self):
+        """Entries with different stems should both pass."""
+        f = StrictRenameFilter()
+        candidates = [
+            _make_resource(
+                title="entry-a",
+                fansub="Fansub_A",
+                quality=VideoQuality.Q1080P,
+                url="magnet:a",
+            ),
+            _make_resource(
+                title="entry-b",
+                fansub="Fansub_B",
+                quality=VideoQuality.Q720P,
+                url="magnet:b",
+            ),
+        ]
+
+        with (
+            patch(_DB_FIND, new_callable=AsyncMock, return_value=[]),
+            patch(_CFG, _mock_config()),
+        ):
+            result = await f.apply(candidates)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_different_episodes_independent(self):
+        """Strict filter is per-episode; different episodes are independent."""
+        f = StrictRenameFilter()
+        candidates = [
+            _make_resource(
+                title="ep1",
+                episode=1,
+                fansub="Fansub_A",
+                quality=VideoQuality.Q1080P,
+                url="magnet:e1",
+            ),
+            _make_resource(
+                title="ep2",
+                episode=2,
+                fansub="Fansub_A",
+                quality=VideoQuality.Q1080P,
+                url="magnet:e2",
+            ),
+        ]
+
+        _mock_find = AsyncMock(
+            side_effect=lambda anime_name, season, episode: (
+                [_make_db_record(fansub="Fansub_A", quality="1080p")]
+                if episode == 1
+                else []
+            )
+        )
+
+        with (
+            patch(_DB_FIND, new=_mock_find),
+            patch(_CFG, _mock_config()),
+        ):
+            result = await f.apply(candidates)
+        # Episode 1: stem matches DB → filtered
+        # Episode 2: no DB records → passes
+        assert len(result) == 1
+        assert result[0].episode == 2

--- a/tests/core/test_priority.py
+++ b/tests/core/test_priority.py
@@ -6,9 +6,10 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from openlist_ani.core.rss.priority import (
-    ResourcePriorityFilter,
+from openlist_ani.core.rss.filter.priority import (
+    PriorityFilter,
     _index_or_none,
+    _language_level,
     _level_sort_key,
 )
 from openlist_ani.core.website.model import (
@@ -59,8 +60,8 @@ def _make_db_record(
 
 
 # Patch targets
-_DB_FIND = "openlist_ani.core.rss.priority.db.find_resources_by_episode"
-_CFG_PRIORITY = "openlist_ani.core.rss.priority.config"
+_DB_FIND = "openlist_ani.core.rss.filter.priority.db.find_resources_by_episode"
+_CFG_PRIORITY = "openlist_ani.core.rss.filter.priority.config"
 
 
 def _mock_config(
@@ -121,7 +122,7 @@ class TestFansubPriority:
     @pytest.mark.asyncio
     async def test_skip_lower_priority_fansub(self):
         """If highest-priority fansub is already downloaded, skip lower ones."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(title="ep1-other", fansub="Fansub_C"),
         ]
@@ -131,13 +132,13 @@ class TestFansubPriority:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=downloaded),
             patch(_CFG_PRIORITY, _mock_config(fansub=["Fansub_B", "Fansub_C"])),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         assert result == []
 
     @pytest.mark.asyncio
     async def test_allow_higher_priority_fansub(self):
         """Higher-priority fansub should still be downloaded."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(title="ep1-ani", fansub="Fansub_B"),
         ]
@@ -147,14 +148,14 @@ class TestFansubPriority:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=downloaded),
             patch(_CFG_PRIORITY, _mock_config(fansub=["Fansub_B", "Fansub_C"])),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         assert len(result) == 1
         assert result[0].fansub == "Fansub_B"
 
     @pytest.mark.asyncio
     async def test_multi_level_fansub_priority(self):
         """With [Fansub_A, Fansub_B], if Fansub_B downloaded, skip all except Fansub_A."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(title="ep1-mmnt", fansub="Fansub_A"),
             _make_resource(title="ep1-random", fansub="Fansub_D", url="magnet:rand"),
@@ -165,7 +166,7 @@ class TestFansubPriority:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=downloaded),
             patch(_CFG_PRIORITY, _mock_config(fansub=["Fansub_A", "Fansub_B"])),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         # Fansub_A has higher priority than Fansub_B → allowed
         # Fansub_D is unranked → skipped (Fansub_B is ranked and downloaded)
         assert len(result) == 1
@@ -174,7 +175,7 @@ class TestFansubPriority:
     @pytest.mark.asyncio
     async def test_top_priority_downloaded_skips_all(self):
         """If top-priority fansub already downloaded, skip everything."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(title="ep1-ani", fansub="Fansub_B"),
             _make_resource(title="ep1-rand", fansub="Fansub_D", url="magnet:r"),
@@ -185,7 +186,7 @@ class TestFansubPriority:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=downloaded),
             patch(_CFG_PRIORITY, _mock_config(fansub=["Fansub_A", "Fansub_B"])),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         assert result == []
 
 
@@ -195,7 +196,7 @@ class TestFansubPriority:
 class TestLanguagePriority:
     @pytest.mark.asyncio
     async def test_skip_lower_priority_language(self):
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(
                 title="ep1-cht",
@@ -208,12 +209,12 @@ class TestLanguagePriority:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=downloaded),
             patch(_CFG_PRIORITY, _mock_config(languages=["简", "繁"], quality=[])),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         assert result == []
 
     @pytest.mark.asyncio
     async def test_allow_higher_priority_language(self):
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(title="ep1-chs", languages=[LanguageType.CHS]),
         ]
@@ -223,13 +224,13 @@ class TestLanguagePriority:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=downloaded),
             patch(_CFG_PRIORITY, _mock_config(languages=["简", "繁"], quality=[])),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         assert len(result) == 1
 
     @pytest.mark.asyncio
     async def test_multi_language_resource_uses_best_match(self):
         """A resource with [简, 日] should use 简 as its language level."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(
                 title="ep1-dual",
@@ -242,7 +243,7 @@ class TestLanguagePriority:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=downloaded),
             patch(_CFG_PRIORITY, _mock_config(languages=["简", "繁"], quality=[])),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         # 简 (idx=0) > 繁 (idx=1) → candidate is better → allowed
         assert len(result) == 1
 
@@ -254,7 +255,7 @@ class TestQualityPriority:
     @pytest.mark.asyncio
     async def test_default_quality_skip_lower(self):
         """Default: 1080p downloaded → skip 720p."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(title="ep1-720", quality=VideoQuality.Q720P),
         ]
@@ -264,13 +265,13 @@ class TestQualityPriority:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=downloaded),
             patch(_CFG_PRIORITY, _mock_config()),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         assert result == []
 
     @pytest.mark.asyncio
     async def test_default_quality_allow_higher(self):
         """Default: 720p downloaded → allow 1080p."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(title="ep1-1080", quality=VideoQuality.Q1080P),
         ]
@@ -280,13 +281,13 @@ class TestQualityPriority:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=downloaded),
             patch(_CFG_PRIORITY, _mock_config()),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         assert len(result) == 1
 
     @pytest.mark.asyncio
     async def test_quality_disabled(self):
         """quality = [] → no quality filtering."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(title="ep1-720", quality=VideoQuality.Q720P),
         ]
@@ -296,7 +297,7 @@ class TestQualityPriority:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=downloaded),
             patch(_CFG_PRIORITY, _mock_config(quality=[])),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         assert len(result) == 1
 
 
@@ -307,7 +308,7 @@ class TestMultiFieldPriority:
     @pytest.mark.asyncio
     async def test_combined_fansub_and_language(self):
         """Skip when both fansub and language are lower priority."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(
                 title="ep1-low",
@@ -328,13 +329,13 @@ class TestMultiFieldPriority:
                 ),
             ),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         assert result == []
 
     @pytest.mark.asyncio
     async def test_higher_priority_field_takes_precedence(self):
         """Better fansub (higher-priority field) overrides worse language."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         # Better fansub, but worse language
         candidates = [
             _make_resource(
@@ -356,7 +357,7 @@ class TestMultiFieldPriority:
                 ),
             ),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         # Fansub is checked first (field_order default): Fansub_B > Fansub_C → allow
         assert len(result) == 1
         assert result[0].fansub == "Fansub_B"
@@ -364,7 +365,7 @@ class TestMultiFieldPriority:
     @pytest.mark.asyncio
     async def test_lower_priority_field_breaks_tie(self):
         """When fansub is tied, language (lower-priority field) breaks the tie."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(
                 title="ep1-cht",
@@ -385,7 +386,7 @@ class TestMultiFieldPriority:
                 ),
             ),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         # Fansub tied (both Fansub_B) → check language: 繁 < 简 → skip
         assert result == []
 
@@ -397,7 +398,7 @@ class TestVersionBypass:
     @pytest.mark.asyncio
     async def test_higher_version_always_passes(self):
         """Version upgrade bypasses priority filtering."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(
                 title="ep1-v2",
@@ -412,13 +413,13 @@ class TestVersionBypass:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=downloaded),
             patch(_CFG_PRIORITY, _mock_config(fansub=["Fansub_A", "Fansub_B"])),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         assert len(result) == 1
 
     @pytest.mark.asyncio
     async def test_same_version_no_bypass(self):
         """Same version does not get the bypass."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(
                 title="ep1-v1-dup",
@@ -437,13 +438,13 @@ class TestVersionBypass:
                 _mock_config(fansub=["Fansub_A", "Fansub_B"], quality=[]),
             ),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         assert result == []
 
     @pytest.mark.asyncio
     async def test_version_bypass_ignores_quality(self):
         """Version comparison ignores quality (per spec)."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(
                 title="ep1-v2-720",
@@ -464,7 +465,7 @@ class TestVersionBypass:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=downloaded),
             patch(_CFG_PRIORITY, _mock_config(fansub=["Fansub_B"])),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         assert len(result) == 1
 
 
@@ -475,7 +476,7 @@ class TestBatchSelection:
     @pytest.mark.asyncio
     async def test_keeps_best_in_batch(self):
         """Within a single batch, only the lexicographically best survive."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(
                 title="ep1-best",
@@ -498,7 +499,7 @@ class TestBatchSelection:
                 _mock_config(fansub=["Fansub_B", "Fansub_C"]),
             ),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         # Fansub_B wins on fansub (first field) → only Fansub_B survives
         assert len(result) == 1
         assert result[0].title == "ep1-best"
@@ -506,7 +507,7 @@ class TestBatchSelection:
     @pytest.mark.asyncio
     async def test_lexicographic_fansub_wins_over_quality(self):
         """With default field_order (fansub first), fansub decides."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(
                 title="ep1-a",
@@ -529,7 +530,7 @@ class TestBatchSelection:
                 _mock_config(fansub=["Fansub_B", "Fansub_C"]),
             ),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         # fansub is checked first: Fansub_B > Fansub_C → only Fansub_B survives
         assert len(result) == 1
         assert result[0].title == "ep1-a"
@@ -537,7 +538,7 @@ class TestBatchSelection:
     @pytest.mark.asyncio
     async def test_keeps_ties(self):
         """Candidates with identical priority levels both survive."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(
                 title="ep1-a",
@@ -560,7 +561,7 @@ class TestBatchSelection:
                 _mock_config(fansub=["Fansub_B", "Fansub_C"]),
             ),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         assert len(result) == 2
 
 
@@ -571,27 +572,27 @@ class TestEdgeCases:
     @pytest.mark.asyncio
     async def test_no_priority_config_passes_all(self):
         """All priority lists empty → everything passes."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(title="a", url="magnet:a"),
             _make_resource(title="b", url="magnet:b"),
         ]
 
         with patch(_CFG_PRIORITY, _mock_config(fansub=[], languages=[], quality=[])):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         assert len(result) == 2
 
     @pytest.mark.asyncio
     async def test_empty_batch(self):
         """Empty batch returns empty list."""
-        f = ResourcePriorityFilter()
-        result = await f.filter_batch([])
+        f = PriorityFilter()
+        result = await f.apply([])
         assert result == []
 
     @pytest.mark.asyncio
     async def test_no_db_records_passes_all(self):
         """No previous downloads → all candidates pass."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(title="ep1-a", fansub="Fansub_B", url="magnet:a"),
             _make_resource(title="ep1-b", fansub="Fansub_C", url="magnet:b"),
@@ -601,7 +602,7 @@ class TestEdgeCases:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=[]),
             patch(_CFG_PRIORITY, _mock_config(fansub=["Fansub_B", "Fansub_C"])),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         # No DB records → batch selection: Fansub_B > Fansub_C on fansub → only Fansub_B
         assert len(result) == 1
         assert result[0].fansub == "Fansub_B"
@@ -609,7 +610,7 @@ class TestEdgeCases:
     @pytest.mark.asyncio
     async def test_candidate_not_in_priority_list(self):
         """Unranked candidate gets skipped when ranked value downloaded."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(title="ep1-unknown", fansub="Fansub_X"),
         ]
@@ -619,26 +620,26 @@ class TestEdgeCases:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=downloaded),
             patch(_CFG_PRIORITY, _mock_config(fansub=["Fansub_B"])),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         assert result == []
 
     @pytest.mark.asyncio
     async def test_missing_metadata_bypasses_filter(self):
         """Entries without anime_name/season/episode bypass priority filtering."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(title="no-meta"),
         ]
         candidates[0].anime_name = None
 
         with patch(_CFG_PRIORITY, _mock_config(fansub=["Fansub_B"])):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         assert len(result) == 1
 
     @pytest.mark.asyncio
     async def test_different_episodes_independent(self):
         """Priority is per-episode; different episodes are independent."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(
                 title="ep1-other", fansub="Fansub_C", episode=1, url="magnet:e1"
@@ -661,7 +662,7 @@ class TestEdgeCases:
                 _mock_config(fansub=["Fansub_B", "Fansub_C"], quality=[]),
             ),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         # Episode 1: Fansub_B already downloaded → Fansub_C skipped
         # Episode 2: no downloads → Fansub_C passes
         assert len(result) == 1
@@ -675,7 +676,7 @@ class TestFieldOrder:
     @pytest.mark.asyncio
     async def test_language_first_overrides_fansub(self):
         """With field_order=[languages, fansub, quality], language decides first."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         # Worse fansub, but better language
         candidates = [
             _make_resource(
@@ -698,14 +699,14 @@ class TestFieldOrder:
                 ),
             ),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         # Language is checked first: 简 > 繁 → candidate is better → allow
         assert len(result) == 1
 
     @pytest.mark.asyncio
     async def test_quality_first_in_batch(self):
         """With field_order=[quality, fansub, languages], quality decides batch selection."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(
                 title="ep1-a",
@@ -731,7 +732,7 @@ class TestFieldOrder:
                 ),
             ),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         # Quality checked first: 1080p > 720p → Fansub_C wins
         assert len(result) == 1
         assert result[0].title == "ep1-b"
@@ -739,7 +740,7 @@ class TestFieldOrder:
     @pytest.mark.asyncio
     async def test_single_field_order(self):
         """field_order with only one field ignores the others."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         # Worse quality, but only fansub in field_order
         candidates = [
             _make_resource(
@@ -760,7 +761,7 @@ class TestFieldOrder:
                 ),
             ),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
         # Only fansub is checked: Fansub_B > Fansub_C → allow (quality ignored)
         assert len(result) == 1
 
@@ -779,7 +780,7 @@ class TestPreInsertedDBFiltering:
     @pytest.mark.asyncio
     async def test_preinserted_blocks_lower_priority_language(self):
         """简日 pre-inserted to DB → 繁日 candidate should be skipped."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(
                 title="ep1-cht",
@@ -806,13 +807,13 @@ class TestPreInsertedDBFiltering:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=db_records),
             patch(_CFG_PRIORITY, cfg),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
             assert result == []
 
     @pytest.mark.asyncio
     async def test_preinserted_allows_higher_priority(self):
         """繁日 pre-inserted to DB → 简日 candidate (higher priority) still passes."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(
                 title="ep1-chs",
@@ -838,14 +839,14 @@ class TestPreInsertedDBFiltering:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=db_records),
             patch(_CFG_PRIORITY, cfg),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
             assert len(result) == 1
             assert result[0].title == "ep1-chs"
 
     @pytest.mark.asyncio
     async def test_preinserted_fansub_blocks_lower_fansub(self):
         """Fansub_A pre-inserted to DB → Fansub_B candidate should be skipped."""
-        f = ResourcePriorityFilter()
+        f = PriorityFilter()
         candidates = [
             _make_resource(
                 title="ep1-fanB",
@@ -862,5 +863,243 @@ class TestPreInsertedDBFiltering:
             patch(_DB_FIND, new_callable=AsyncMock, return_value=db_records),
             patch(_CFG_PRIORITY, cfg),
         ):
-            result = await f.filter_batch(candidates)
+            result = await f.apply(candidates)
             assert result == []
+
+
+# ── _language_level unit tests ──────────────────────────────────────
+
+
+class TestLanguageLevel:
+    """Tests for the _language_level helper function."""
+
+    def test_exact_match_single_char(self):
+        """Single-character exact match."""
+        assert _language_level("简", ["简", "繁"]) == 0
+
+    def test_exact_match_multi_char(self):
+        """Multi-character exact match (e.g., 简繁 dual)."""
+        assert _language_level("简繁", ["简", "简繁", "繁"]) == 1
+
+    def test_contains_fallback(self):
+        """No exact match → falls back to single-char contains."""
+        # "简繁" not in ["简", "繁"], but "简" is in "简繁"
+        assert _language_level("简繁", ["简", "繁"]) == 0
+
+    def test_contains_fallback_best_match(self):
+        """Contains fallback picks the best (lowest index) match."""
+        # "日简" contains both "日"(idx=2) and "简"(idx=0) → best is 0
+        assert _language_level("日简", ["简", "繁", "日"]) == 0
+
+    def test_no_match(self):
+        """No match at all → None."""
+        assert _language_level("英", ["简", "繁"]) is None
+
+    def test_exact_match_takes_precedence_over_contains(self):
+        """Exact match wins even if a contains fallback has a better index."""
+        # "简繁" matches exactly at index 2, even though "简" (index 0) contains
+        assert _language_level("简繁", ["简", "繁", "简繁"]) == 2
+
+    def test_empty_priority_list(self):
+        """Empty priority list → None."""
+        assert _language_level("简", []) is None
+
+    def test_empty_lang_str(self):
+        """Empty language string → None (no match possible)."""
+        assert _language_level("", ["简", "繁"]) is None
+
+    def test_sorting_consistency(self):
+        """Sorting ensures order-independent matching."""
+        # "繁简" sorted = "简繁", "简繁" sorted = "简繁" → match
+        assert _language_level("繁简", ["简繁"]) == 0
+        assert _language_level("简繁", ["繁简"]) == 0
+
+
+# ── language priority combination tests (integration) ──────────────
+
+
+class TestLanguagePriorityCombination:
+    """Integration tests for distinguishing pure CHS from CHS+CHT dual."""
+
+    @pytest.mark.asyncio
+    async def test_pure_chs_preferred_over_dual_chs_cht(self):
+        """With ['简', '简繁', '繁'], pure CHS beats CHS+CHT in batch selection."""
+        f = PriorityFilter()
+        candidates = [
+            _make_resource(
+                title="ep1-dual",
+                languages=[LanguageType.CHS, LanguageType.CHT],
+                url="magnet:dual",
+            ),
+            _make_resource(
+                title="ep1-chs",
+                languages=[LanguageType.CHS],
+                url="magnet:chs",
+            ),
+        ]
+
+        with (
+            patch(_DB_FIND, new_callable=AsyncMock, return_value=[]),
+            patch(
+                _CFG_PRIORITY,
+                _mock_config(
+                    languages=["简", "简繁", "繁"],
+                    quality=[],
+                ),
+            ),
+        ):
+            result = await f.apply(candidates)
+        # pure CHS (idx=0) beats CHS+CHT dual (idx=1)
+        assert len(result) == 1
+        assert result[0].title == "ep1-chs"
+
+    @pytest.mark.asyncio
+    async def test_dual_chs_cht_preferred_over_pure_cht(self):
+        """With ['简', '简繁', '繁'], CHS+CHT dual beats pure CHT."""
+        f = PriorityFilter()
+        candidates = [
+            _make_resource(
+                title="ep1-cht",
+                languages=[LanguageType.CHT],
+                url="magnet:cht",
+            ),
+            _make_resource(
+                title="ep1-dual",
+                languages=[LanguageType.CHS, LanguageType.CHT],
+                url="magnet:dual",
+            ),
+        ]
+
+        with (
+            patch(_DB_FIND, new_callable=AsyncMock, return_value=[]),
+            patch(
+                _CFG_PRIORITY,
+                _mock_config(
+                    languages=["简", "简繁", "繁"],
+                    quality=[],
+                ),
+            ),
+        ):
+            result = await f.apply(candidates)
+        # CHS+CHT dual (idx=1) beats pure CHT (idx=2)
+        assert len(result) == 1
+        assert result[0].title == "ep1-dual"
+
+    @pytest.mark.asyncio
+    async def test_backward_compatible_dual_matches_via_fallback(self):
+        """With old config ['简', '繁'], CHS+CHT dual matches '简' via fallback."""
+        f = PriorityFilter()
+        candidates = [
+            _make_resource(
+                title="ep1-dual",
+                languages=[LanguageType.CHS, LanguageType.CHT],
+                url="magnet:dual",
+            ),
+        ]
+        # Downloaded: pure CHT
+        downloaded = [_make_db_record(languages="繁")]
+
+        with (
+            patch(_DB_FIND, new_callable=AsyncMock, return_value=downloaded),
+            patch(
+                _CFG_PRIORITY,
+                _mock_config(
+                    languages=["简", "繁"],
+                    quality=[],
+                ),
+            ),
+        ):
+            result = await f.apply(candidates)
+        # CHS+CHT dual → contains fallback "简" (idx=0) > downloaded "繁" (idx=1) → allow
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_pure_chs_downloaded_skips_dual(self):
+        """With ['简', '简繁', '繁'], if pure CHS downloaded, CHS+CHT dual is skipped."""
+        f = PriorityFilter()
+        candidates = [
+            _make_resource(
+                title="ep1-dual",
+                languages=[LanguageType.CHS, LanguageType.CHT],
+            ),
+        ]
+        # Downloaded: pure CHS
+        downloaded = [_make_db_record(languages="简")]
+
+        with (
+            patch(_DB_FIND, new_callable=AsyncMock, return_value=downloaded),
+            patch(
+                _CFG_PRIORITY,
+                _mock_config(
+                    languages=["简", "简繁", "繁"],
+                    quality=[],
+                ),
+            ),
+        ):
+            result = await f.apply(candidates)
+        # pure CHS (idx=0) already downloaded → CHS+CHT (idx=1) is worse → skip
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_dual_downloaded_allows_pure_chs(self):
+        """With ['简', '简繁', '繁'], if dual downloaded, pure CHS still allowed."""
+        f = PriorityFilter()
+        candidates = [
+            _make_resource(
+                title="ep1-chs",
+                languages=[LanguageType.CHS],
+            ),
+        ]
+        # Downloaded: CHS+CHT dual
+        downloaded = [_make_db_record(languages="简繁")]
+
+        with (
+            patch(_DB_FIND, new_callable=AsyncMock, return_value=downloaded),
+            patch(
+                _CFG_PRIORITY,
+                _mock_config(
+                    languages=["简", "简繁", "繁"],
+                    quality=[],
+                ),
+            ),
+        ):
+            result = await f.apply(candidates)
+        # pure CHS (idx=0) is better than CHS+CHT dual (idx=1) → allow
+        assert len(result) == 1
+        assert result[0].title == "ep1-chs"
+
+    @pytest.mark.asyncio
+    async def test_chs_jp_dual_fallback_allows_both_with_pure_chs(self):
+        """With ['简', '简繁'], CHS+JP dual falls back to '简' — both it and pure CHS download."""
+        f = PriorityFilter()
+        candidates = [
+            _make_resource(
+                title="ep1-chs",
+                languages=[LanguageType.CHS],
+                url="magnet:chs",
+            ),
+            _make_resource(
+                title="ep1-chs-jp",
+                languages=[LanguageType.CHS, LanguageType.JP],
+                url="magnet:chsjp",
+            ),
+        ]
+
+        with (
+            patch(_DB_FIND, new_callable=AsyncMock, return_value=[]),
+            patch(
+                _CFG_PRIORITY,
+                _mock_config(
+                    languages=["简", "简繁"],
+                    quality=[],
+                ),
+            ),
+        ):
+            result = await f.apply(candidates)
+        # pure CHS → exact match "简" (idx=0)
+        # CHS+JP → no exact match for "日简", fallback contains "简" (idx=0)
+        # Both have the same level → both are downloaded
+        assert len(result) == 2
+        titles = {r.title for r in result}
+        assert "ep1-chs" in titles
+        assert "ep1-chs-jp" in titles

--- a/tests/manual_test_script/parser_test.py
+++ b/tests/manual_test_script/parser_test.py
@@ -68,7 +68,7 @@ class PerfStats:
 
 
 _stats: PerfStats | None = None
-_OriginalOpenAILLMClient = parser_module.OpenAILLMClient
+_OriginalCreateLLMClient = parser_module.create_llm_client
 _OriginalGetTMDBClient = parser_module.get_tmdb_client
 
 
@@ -393,7 +393,18 @@ async def main() -> None:
             format="<level>{level: <8}</level> | {message}",
         )
 
-    parser_module.OpenAILLMClient = TrackedOpenAILLMClient
+    def _create_tracked_llm_client(llm_config):
+        client = _OriginalCreateLLMClient(llm_config)
+        if isinstance(client, OpenAILLMClient):
+            tracked = TrackedOpenAILLMClient(
+                api_key=llm_config.openai_api_key,
+                base_url=llm_config.openai_base_url,
+                model=llm_config.openai_model,
+            )
+            return tracked
+        return client
+
+    parser_module.create_llm_client = _create_tracked_llm_client
     parser_module.get_tmdb_client = _get_tracked_tmdb_client
     try:
         _stats = PerfStats()
@@ -413,7 +424,7 @@ async def main() -> None:
 
         sys.exit(0 if all_passed else 1)
     finally:
-        parser_module.OpenAILLMClient = _OriginalOpenAILLMClient
+        parser_module.create_llm_client = _OriginalCreateLLMClient
         parser_module.get_tmdb_client = _OriginalGetTMDBClient
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ from openlist_ani.config import (
     ConfigManager,
     LLMConfig,
     LogConfig,
+    MetadataFilterConfig,
     NotificationConfig,
     OpenListConfig,
     ProxyConfig,
@@ -522,3 +523,170 @@ class TestProxyEnvVars:
         # Access data — should not crash
         d = mgr.data
         assert isinstance(d, UserConfig)
+
+
+class TestRenameFormatValidation:
+    """Tests for rename_format field validation in ConfigManager.validate()."""
+
+    def test_valid_default_format_passes(self, tmp_path, monkeypatch):
+        """Default rename_format should pass validation."""
+        monkeypatch.chdir(tmp_path)
+        mgr = ConfigManager("config.toml")
+        mgr._config.rss.urls = ["https://example.com/feed"]
+        mgr._config.openlist.url = "https://localhost"
+        mgr._config.openlist.token = "tok"
+        mgr._config.llm.openai_api_key = "key"
+        mgr.save()
+        assert mgr.validate() is True
+
+    def test_valid_custom_format_passes(self, tmp_path, monkeypatch):
+        """Custom format with only supported fields should pass."""
+        monkeypatch.chdir(tmp_path)
+        mgr = ConfigManager("config.toml")
+        mgr._config.rss.urls = ["https://example.com/feed"]
+        mgr._config.openlist.url = "https://localhost"
+        mgr._config.openlist.token = "tok"
+        mgr._config.llm.openai_api_key = "key"
+        mgr._config.openlist.rename_format = "{anime_name} E{episode:02d}"
+        mgr.save()
+        assert mgr.validate() is True
+
+    def test_unsupported_field_fails(self, tmp_path, monkeypatch):
+        """Format with unsupported field name should fail validation."""
+        monkeypatch.chdir(tmp_path)
+        mgr = ConfigManager("config.toml")
+        mgr._config.rss.urls = ["https://example.com/feed"]
+        mgr._config.openlist.url = "https://localhost"
+        mgr._config.openlist.token = "tok"
+        mgr._config.llm.openai_api_key = "key"
+        mgr._config.openlist.rename_format = (
+            "{anime_name} {nonexistent_field}"
+        )
+        mgr.save()
+        assert mgr.validate() is False
+
+    def test_empty_format_no_error(self, tmp_path, monkeypatch):
+        """Empty format string should not cause validation error."""
+        monkeypatch.chdir(tmp_path)
+        mgr = ConfigManager("config.toml")
+        mgr._config.rss.urls = ["https://example.com/feed"]
+        mgr._config.openlist.url = "https://localhost"
+        mgr._config.openlist.token = "tok"
+        mgr._config.llm.openai_api_key = "key"
+        mgr._config.openlist.rename_format = ""
+        mgr.save()
+        assert mgr.validate() is True
+
+    def test_all_supported_fields_pass(self, tmp_path, monkeypatch):
+        """Format using all supported fields should pass."""
+        monkeypatch.chdir(tmp_path)
+        mgr = ConfigManager("config.toml")
+        mgr._config.rss.urls = ["https://example.com/feed"]
+        mgr._config.openlist.url = "https://localhost"
+        mgr._config.openlist.token = "tok"
+        mgr._config.llm.openai_api_key = "key"
+        mgr._config.openlist.rename_format = (
+            "{anime_name} S{season}E{episode} "
+            "{fansub} {quality} {languages}"
+        )
+        mgr.save()
+        assert mgr.validate() is True
+
+
+class TestRSSConfigStrict:
+    """Tests for the strict field in RSSConfig."""
+
+    def test_default_is_false(self):
+        cfg = RSSConfig()
+        assert cfg.strict is False
+
+    def test_set_to_true(self):
+        cfg = RSSConfig(strict=True)
+        assert cfg.strict is True
+
+
+class TestRSSConfigExcludePatterns:
+    """Tests for the exclude_patterns field in MetadataFilterConfig."""
+
+    def test_default_is_empty(self):
+        cfg = MetadataFilterConfig()
+        assert cfg.exclude_patterns == []
+
+    def test_set_patterns(self):
+        cfg = MetadataFilterConfig(exclude_patterns=["合集", "SP\\d+"])
+        assert len(cfg.exclude_patterns) == 2
+        assert "合集" in cfg.exclude_patterns
+
+
+class TestMetadataFilterConfig:
+    """Tests for MetadataFilterConfig defaults and values."""
+
+    def test_defaults(self):
+        cfg = MetadataFilterConfig()
+        assert cfg.exclude_fansub == []
+        assert cfg.exclude_quality == []
+        assert cfg.exclude_languages == []
+        assert cfg.exclude_patterns == []
+
+    def test_custom_values(self):
+        cfg = MetadataFilterConfig(
+            exclude_fansub=["BadSub"],
+            exclude_quality=["480p"],
+            exclude_languages=["未知"],
+        )
+        assert cfg.exclude_fansub == ["BadSub"]
+        assert cfg.exclude_quality == ["480p"]
+        assert cfg.exclude_languages == ["未知"]
+
+    def test_rss_config_includes_filter(self):
+        cfg = RSSConfig()
+        assert isinstance(cfg.filter, MetadataFilterConfig)
+
+
+class TestExcludePatternsValidation:
+    """Tests for exclude_patterns regex validation in ConfigManager.validate()."""
+
+    def test_valid_patterns_pass(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        mgr = ConfigManager("config.toml")
+        mgr._config.rss.urls = ["https://example.com/feed"]
+        mgr._config.openlist.url = "https://localhost"
+        mgr._config.openlist.token = "tok"
+        mgr._config.llm.openai_api_key = "key"
+        mgr._config.rss.filter.exclude_patterns = ["合集", "SP\\d+", "HEVC"]
+        mgr.save()
+        assert mgr.validate() is True
+
+    def test_invalid_regex_fails(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        mgr = ConfigManager("config.toml")
+        mgr._config.rss.urls = ["https://example.com/feed"]
+        mgr._config.openlist.url = "https://localhost"
+        mgr._config.openlist.token = "tok"
+        mgr._config.llm.openai_api_key = "key"
+        mgr._config.rss.filter.exclude_patterns = ["[invalid"]
+        mgr.save()
+        assert mgr.validate() is False
+
+    def test_empty_patterns_pass(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        mgr = ConfigManager("config.toml")
+        mgr._config.rss.urls = ["https://example.com/feed"]
+        mgr._config.openlist.url = "https://localhost"
+        mgr._config.openlist.token = "tok"
+        mgr._config.llm.openai_api_key = "key"
+        mgr._config.rss.filter.exclude_patterns = []
+        mgr.save()
+        assert mgr.validate() is True
+
+    def test_mixed_valid_invalid_fails(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        mgr = ConfigManager("config.toml")
+        mgr._config.rss.urls = ["https://example.com/feed"]
+        mgr._config.openlist.url = "https://localhost"
+        mgr._config.openlist.token = "tok"
+        mgr._config.llm.openai_api_key = "key"
+        mgr._config.rss.filter.exclude_patterns = ["valid_regex", "(unclosed"]
+        mgr.save()
+        assert mgr.validate() is False
+

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -5,10 +5,11 @@ import pytest
 from openlist_ani.database import AniDatabase
 
 
-@pytest.fixture
-async def test_db(tmp_path):
-    """Create a temporary database for testing."""
-    db = AniDatabase(db_path=tmp_path / "test.db")
+@pytest.fixture(scope="module")
+async def test_db(tmp_path_factory):
+    """Create a single temporary database shared across all tests in this module."""
+    tmp = tmp_path_factory.mktemp("db")
+    db = AniDatabase(db_path=tmp / "test.db")
     await db.init()
     return db
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7,6 +7,10 @@ from unittest.mock import AsyncMock, patch
 from openlist_ani.core.website.model import AnimeResourceInfo, VideoQuality
 
 
+class _StopPoll(Exception):
+    """Sentinel exception used to break the worker's poll loop in tests."""
+
+
 def _make_resource(
     title: str = "Test Anime - 01",
     download_url: str = "magnet:?xt=urn:btih:abc123",
@@ -54,7 +58,7 @@ async def _run_dispatch_once(queue, mock_manager):
         mock_config.openlist.download_path = "/downloads"
 
         try:
-            async with asyncio.timeout(0.1):
+            async with asyncio.timeout(0.02):
                 await DownloadDispatcher(mock_manager, queue, active).run()
         except TimeoutError:
             pass
@@ -68,6 +72,10 @@ async def _run_poll_once(rss_entries, parse_results):
     mock_rss = AsyncMock()
     mock_rss.check_update = AsyncMock(return_value=rss_entries)
 
+    async def _cancel_sleep(_seconds: float) -> None:
+        """Interrupt the worker's inter-poll sleep so we exit immediately."""
+        raise _StopPoll
+
     with (
         patch(
             "openlist_ani.backend.worker.parse_metadata",
@@ -76,25 +84,38 @@ async def _run_poll_once(rss_entries, parse_results):
         ) as mock_parse,
         patch("openlist_ani.backend.worker.config") as mock_config,
         patch(
-            "openlist_ani.core.rss.priority.db.find_resources_by_episode",
+            "openlist_ani.core.rss.filter.priority.db.find_resources_by_episode",
             new_callable=AsyncMock,
             return_value=[],
         ),
         patch(
             "openlist_ani.backend.worker.db",
         ) as mock_db,
+        patch(
+            "openlist_ani.backend.worker.asyncio.sleep",
+            side_effect=_cancel_sleep,
+        ),
     ):
         mock_config.rss.interval_time = 999
+        mock_config.rss.strict = False
+        mock_config.rss.filter.exclude_patterns = []
+        mock_config.rss.filter.exclude_fansub = []
+        mock_config.rss.filter.exclude_quality = []
+        mock_config.rss.filter.exclude_languages = []
+        mock_config.rss.filter.model_copy = lambda deep=False: mock_config.rss.filter
         mock_config.rss.priority.fansub = []
         mock_config.rss.priority.languages = []
         mock_config.rss.priority.quality = []
         mock_config.rss.priority.field_order = []
+        mock_config.rss.priority.model_copy = lambda deep=False: mock_config.rss.priority
+        mock_config.openlist.rename_format = (
+            "{anime_name} S{season:02d}E{episode:02d}"
+        )
         mock_db.add_resource = AsyncMock()
 
         try:
-            async with asyncio.timeout(0.2):
-                await RSSPollWorker(mock_rss, queue).run()
-        except TimeoutError:
+            await RSSPollWorker(mock_rss, queue).run()
+        except _StopPoll:
             pass
 
     queued = []


### PR DESCRIPTION
1. 支持根据正则表达式过滤指定title的rss
2. 支持根据解析后的metadata过滤指定的rss
3. 优化language对应的优先级配置，支持多语种优先级 #94 
4. 修复上轮PR #95 引入的，parser不支持anthropic格式client的问题

 