### PR TITLE
fix(bangumi): use episode batch API for anime progress updates

### DIFF
--- a/skills/bangumi/script/update_collection.py
+++ b/skills/bangumi/script/update_collection.py
@@ -1,7 +1,74 @@
-"""Update collection status, rating, or episode progress on Bangumi."""
+from __future__ import annotations
 
 from openlist_ani.config import config
 from openlist_ani.core.bangumi.client import BangumiClient
+
+_STATUS_NAMES = {1: "wish", 2: "done", 3: "doing", 4: "on_hold", 5: "dropped"}
+
+
+def _parse_params(
+    collection_type: str,
+    rate: str,
+    comment: str,
+    ep_status: str,
+) -> tuple[int | None, int | None, str | None, int | None]:
+    """Parse raw string params into typed values (None means unchanged)."""
+    ct = int(collection_type) if collection_type else None
+    r = int(rate) if rate else None
+    cmt = comment or None
+    ep = int(ep_status) if ep_status else None
+    return ct, r, cmt, ep
+
+
+def _build_summary(
+    subject_id: str,
+    ct: int | None,
+    r: int | None,
+    cmt: str | None,
+    ep: int | None,
+) -> str:
+    """Build a human-readable summary of what was updated."""
+    parts: list[str] = []
+    if ct:
+        parts.append(f"status={_STATUS_NAMES.get(ct, ct)}")
+    if r is not None:
+        parts.append(f"rate={r}/10")
+    if ep is not None:
+        parts.append(f"ep_status={ep}")
+    if cmt:
+        parts.append(f"comment='{cmt[:50]}...'")
+    return f"Collection updated for subject {subject_id}: {', '.join(parts)}"
+
+
+async def _apply_updates(
+    client: BangumiClient,
+    sid: int,
+    ct: int | None,
+    r: int | None,
+    cmt: str | None,
+    ep: int | None,
+) -> None:
+    """Send the actual API requests to Bangumi."""
+    has_metadata = ct is not None or r is not None or cmt is not None
+
+    # POST requires 'type'; default to 3 (doing) when not provided.
+    if has_metadata:
+        await client.post_user_collection(
+            subject_id=sid,
+            collection_type=ct if ct is not None else 3,
+            rate=r,
+            comment=cmt,
+        )
+
+    if ep is not None:
+        # Ensure the subject is collected before updating episodes.
+        if not has_metadata:
+            await client.post_user_collection(
+                subject_id=sid, collection_type=3,
+            )
+        await client.update_episode_progress(
+            subject_id=sid, watched_eps=ep,
+        )
 
 
 async def run(
@@ -29,37 +96,20 @@ async def run(
     if not token:
         return "Error: Bangumi access token not configured."
 
-    ct = int(collection_type) if collection_type else None
-    r = int(rate) if rate else None
-    ep = int(ep_status) if ep_status else None
-    cmt = comment if comment else None
+    ct, r, cmt, ep = _parse_params(collection_type, rate, comment, ep_status)
 
     if ct is None and r is None and ep is None and cmt is None:
-        return "Error: At least one of collection_type, rate, comment, or ep_status must be provided."
+        return (
+            "Error: At least one of collection_type, rate, "
+            "comment, or ep_status must be provided."
+        )
 
     client = BangumiClient(access_token=token)
     try:
-        await client.post_user_collection(
-            subject_id=int(subject_id),
-            collection_type=ct,
-            rate=r,
-            comment=cmt,
-            ep_status=ep,
-        )
+        await _apply_updates(client, int(subject_id), ct, r, cmt, ep)
     except Exception as e:
         return f"Error updating collection: {e}"
     finally:
         await client.close()
 
-    updates = []
-    if ct:
-        names = {1: "wish", 2: "done", 3: "doing", 4: "on_hold", 5: "dropped"}
-        updates.append(f"status={names.get(ct, ct)}")
-    if r is not None:
-        updates.append(f"rate={r}/10")
-    if ep is not None:
-        updates.append(f"ep_status={ep}")
-    if cmt:
-        updates.append(f"comment='{cmt[:50]}...'")
-
-    return f"Collection updated for subject {subject_id}: {', '.join(updates)}"
+    return _build_summary(subject_id, ct, r, cmt, ep)

--- a/src/openlist_ani/core/bangumi/client.py
+++ b/src/openlist_ani/core/bangumi/client.py
@@ -368,14 +368,10 @@ class BangumiClient:
         comment: str | None = None,
         tags: list[str] | None = None,
         private: bool | None = None,
-        ep_status: int | None = None,
     ) -> None:
         """Create or modify a collection entry for the current user.
 
-        Uses POST ``/v0/users/-/collections/{subject_id}`` to create /
-        set the collection type, then PATCH the same endpoint when
-        ``ep_status`` is provided (the POST endpoint does **not** accept
-        ``ep_status``).
+        Uses POST ``/v0/users/-/collections/{subject_id}``.
 
         Args:
             subject_id: Bangumi subject ID.
@@ -385,14 +381,12 @@ class BangumiClient:
             comment: User comment/review text.
             tags: List of tags.
             private: Whether the collection is private.
-            ep_status: Number of watched episodes.
 
         Raises:
             aiohttp.ClientResponseError: On API errors.
         """
         path = f"/v0/users/-/collections/{subject_id}"
 
-        # --- Step 1: POST to create / update the collection entry ----
         post_body: dict[str, Any] = {}
         if collection_type is not None:
             post_body["type"] = collection_type
@@ -408,16 +402,78 @@ class BangumiClient:
         if post_body:
             await self._request("POST", path, json_body=post_body)
 
-        # --- Step 2: PATCH to set ep_status (not supported by POST) --
-        if ep_status is not None:
-            await self._request("PATCH", path, json_body={"ep_status": ep_status})
-
         # Invalidate collection cache since we modified it
         clear_cache(self.fetch_user_collections)
 
         logger.info(
             f"Bangumi: Updated collection for subject {subject_id} "
-            f"(type={collection_type}, ep_status={ep_status})"
+            f"(type={collection_type})"
+        )
+
+    async def update_episode_progress(
+        self,
+        subject_id: int,
+        watched_eps: int,
+    ) -> None:
+        """Set episode progress so that exactly eps 1-*watched_eps* are "done".
+
+        Episodes after *watched_eps* that were previously marked are reset
+        to uncollected (type=0), ensuring the progress is accurate even when
+        the user rewinds.
+
+        Uses ``GET /v0/episodes`` to resolve episode IDs, then
+        ``PATCH /v0/users/-/collections/{subject_id}/episodes`` to batch-
+        update them.  The API automatically recalculates the subject's
+        completion progress.
+
+        Args:
+            subject_id: Bangumi subject ID.
+            watched_eps: Number of episodes watched (from ep 1).
+
+        Raises:
+            ValueError: When *watched_eps* < 1 or no episodes found.
+            aiohttp.ClientResponseError: On API errors.
+        """
+        if watched_eps < 1:
+            raise ValueError("watched_eps must be >= 1")
+
+        episodes = await self.fetch_subject_episodes(
+            subject_id, episode_type=0,
+        )
+        # Sort by ep number and take the first N
+        episodes.sort(key=lambda e: e.get("sort", e.get("ep", 0)))
+
+        watched = episodes[:watched_eps]
+        remaining = episodes[watched_eps:]
+
+        if not watched:
+            raise ValueError(
+                f"No main-story episodes found for subject {subject_id}"
+            )
+
+        path = f"/v0/users/-/collections/{subject_id}/episodes"
+
+        # Mark eps 1..N as done (type=2)
+        watched_ids = [ep["id"] for ep in watched]
+        await self._request(
+            "PATCH", path,
+            json_body={"episode_id": watched_ids, "type": 2},
+        )
+
+        # Reset eps N+1.. to uncollected (type=0) so progress rewinds work
+        if remaining:
+            remaining_ids = [ep["id"] for ep in remaining]
+            await self._request(
+                "PATCH", path,
+                json_body={"episode_id": remaining_ids, "type": 0},
+            )
+
+        # Invalidate collection cache since we modified it
+        clear_cache(self.fetch_user_collections)
+
+        logger.info(
+            f"Bangumi: Set episode progress for subject {subject_id} "
+            f"to {watched_eps}/{len(episodes)}"
         )
 
     async def fetch_subject_episodes(


### PR DESCRIPTION
## Summary
- Bangumi API 的 `ep_status` 字段仅适用于书籍条目，对动画条目会返回 400 Bad Request
- 移除 `post_user_collection` 中错误的 `ep_status` PATCH 逻辑
- 新增 `update_episode_progress` 方法，使用正确的 `PATCH /v0/users/-/collections/{id}/episodes` 批量端点
- 回退进度时自动将超出的集数重置为未收藏（type=0）
- 修复 skill 脚本中的 import 路径

## Test plan
- [x] E2E 测试：仅传 ep_status 更新进度 → 成功
- [x] E2E 测试：传 collection_type + rate → 成功
- [x] E2E 测试：全部参数 → 成功
- [x] E2E 测试：回退进度（第4集→第3集）→ 第4集正确重置为未收藏

🤖 Generated with [Claude Code](https://claude.com/claude-code)