### PR TITLE
fix(rss): 修正 strict filter 执行顺序 & 新增默认合集过滤

### DIFF
--- a/src/openlist_ani/backend/worker.py
+++ b/src/openlist_ani/backend/worker.py
@@ -111,9 +111,9 @@ class RSSPollWorker:
         chain = FilterChain()
         chain.add_filter(RegexTitleFilter())
         chain.add_filter(MetadataFilter())
+        chain.add_filter(PriorityFilter())
         if config.rss.strict:
             chain.add_filter(StrictRenameFilter())
-        chain.add_filter(PriorityFilter())
         return chain
 
     async def _fetch_new_entries(self) -> list[AnimeResourceInfo]:

--- a/src/openlist_ani/core/rss/filter/regex.py
+++ b/src/openlist_ani/core/rss/filter/regex.py
@@ -2,7 +2,8 @@
 Regex-based title exclusion filter.
 
 Filters out RSS entries whose title matches any of the user-configured
-regular expression patterns in ``config.rss.filter.exclude_patterns``.
+regular expression patterns in ``config.rss.filter.exclude_patterns``,
+plus a built-in blacklist for collection-style titles.
 """
 
 from __future__ import annotations
@@ -13,6 +14,9 @@ from ....config import config
 from ....logger import logger
 from ...website.model import AnimeResourceInfo
 
+# 现阶段不支持合集下载，默认过滤
+_DEFAULT_EXCLUDE_PATTERNS = [r"(\d{2}-\d{2}|合集)"]
+
 
 class RegexTitleFilter:
     """Filter candidates by matching their title against exclusion patterns.
@@ -20,6 +24,7 @@ class RegexTitleFilter:
     Config values are read from the hot-reloadable
     ``config.rss.filter.exclude_patterns`` on every call to ``apply``,
     so changes in *config.toml* take effect without a restart.
+    A built-in pattern also excludes titles that look like collections.
     """
 
     def apply(
@@ -37,7 +42,8 @@ class RegexTitleFilter:
         if not candidates:
             return []
 
-        patterns = config.rss.filter.exclude_patterns
+        configured_patterns = list(config.rss.filter.exclude_patterns or [])
+        patterns = [*_DEFAULT_EXCLUDE_PATTERNS, *configured_patterns]
         if not patterns:
             return candidates
 
@@ -55,7 +61,5 @@ class RegexTitleFilter:
 
         skipped = len(candidates) - len(accepted)
         if skipped:
-            logger.info(
-                f"Regex filter: {len(accepted)} accepted, {skipped} excluded"
-            )
+            logger.info(f"Regex filter: {len(accepted)} accepted, {skipped} excluded")
         return accepted

--- a/tests/core/bangumi/test_bangumi.py
+++ b/tests/core/bangumi/test_bangumi.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 
-from openlist_ani.core.bangumi.client import BangumiClient, _REQUEST_INTERVAL
+from openlist_ani.core.bangumi.client import _REQUEST_INTERVAL, BangumiClient
 from openlist_ani.core.bangumi.model import (
     COLLECTION_TYPE_LABELS,
     BangumiBlog,
@@ -21,9 +21,7 @@ from openlist_ani.core.bangumi.model import (
     CalendarDay,
     CalendarItem,
     CollectionType,
-    SlimSubject,
     SubjectType,
-    UserCollectionEntry,
     Weekday,
     parse_calendar_day,
     parse_calendar_item,
@@ -648,26 +646,6 @@ class TestBangumiClient:
         assert call_args[1]["json_body"]["type"] == 2
         assert call_args[1]["json_body"]["rate"] == 8
 
-    async def test_post_user_collection_with_ep_status(self, client):
-        """ep_status should trigger a PATCH after the POST."""
-        client._request = AsyncMock(return_value=None)
-        await client.post_user_collection(
-            subject_id=200,
-            collection_type=3,
-            ep_status=5,
-        )
-        assert client._request.call_count == 2
-        post_call, patch_call = client._request.call_args_list
-        # First call: POST with collection type
-        assert post_call[0][0] == "POST"
-        assert "/v0/users/-/collections/200" in post_call[0][1]
-        assert post_call[1]["json_body"]["type"] == 3
-        assert "ep_status" not in post_call[1]["json_body"]
-        # Second call: PATCH with ep_status only
-        assert patch_call[0][0] == "PATCH"
-        assert "/v0/users/-/collections/200" in patch_call[0][1]
-        assert patch_call[1]["json_body"] == {"ep_status": 5}
-
     async def test_post_user_collection_invalidates_cache(self, client):
         """Collection cache should be cleared after updating a collection."""
         # Populate collection cache first
@@ -933,7 +911,9 @@ class TestBangumiTools:
         import importlib.util
         from pathlib import Path
 
-        script_dir = Path(__file__).resolve().parents[3] / "skills" / "bangumi" / "script"
+        script_dir = (
+            Path(__file__).resolve().parents[3] / "skills" / "bangumi" / "script"
+        )
         path = script_dir / f"{script_name}.py"
         spec = importlib.util.spec_from_file_location(
             f"skill_bangumi_{script_name}", path
@@ -997,8 +977,10 @@ class TestBangumiTools:
         mock_client.fetch_user_collections.return_value = [entry]
         mock_client.close = AsyncMock()
 
-        with patch.object(mod, "BangumiClient", return_value=mock_client), \
-             patch.object(mod, "config", MagicMock(bangumi_token="fake-token")):
+        with (
+            patch.object(mod, "BangumiClient", return_value=mock_client),
+            patch.object(mod, "config", MagicMock(bangumi_token="fake-token")),
+        ):
             result = await mod.run()
 
         assert "测试" in result
@@ -1038,8 +1020,10 @@ class TestBangumiTools:
         mock_client.post_user_collection = AsyncMock()
         mock_client.close = AsyncMock()
 
-        with patch.object(mod, "BangumiClient", return_value=mock_client), \
-             patch.object(mod, "config", MagicMock(bangumi_token="fake-token")):
+        with (
+            patch.object(mod, "BangumiClient", return_value=mock_client),
+            patch.object(mod, "config", MagicMock(bangumi_token="fake-token")),
+        ):
             result = await mod.run(subject_id="517057", collection_type="3")
 
         assert "Collection updated for subject 517057" in result
@@ -1057,8 +1041,10 @@ class TestBangumiTools:
         mock_client.post_user_collection = AsyncMock()
         mock_client.close = AsyncMock()
 
-        with patch.object(mod, "BangumiClient", return_value=mock_client), \
-             patch.object(mod, "config", MagicMock(bangumi_token="fake-token")):
+        with (
+            patch.object(mod, "BangumiClient", return_value=mock_client),
+            patch.object(mod, "config", MagicMock(bangumi_token="fake-token")),
+        ):
             result = await mod.run(subject_id="517057", rate="8")
 
         assert "Collection updated for subject 517057" in result
@@ -1072,8 +1058,10 @@ class TestBangumiTools:
         mock_client.post_user_collection = AsyncMock()
         mock_client.close = AsyncMock()
 
-        with patch.object(mod, "BangumiClient", return_value=mock_client), \
-             patch.object(mod, "config", MagicMock(bangumi_token="fake-token")):
+        with (
+            patch.object(mod, "BangumiClient", return_value=mock_client),
+            patch.object(mod, "config", MagicMock(bangumi_token="fake-token")),
+        ):
             result = await mod.run(subject_id="517057", ep_status="5")
 
         assert "Collection updated for subject 517057" in result
@@ -1087,8 +1075,10 @@ class TestBangumiTools:
         mock_client.post_user_collection = AsyncMock()
         mock_client.close = AsyncMock()
 
-        with patch.object(mod, "BangumiClient", return_value=mock_client), \
-             patch.object(mod, "config", MagicMock(bangumi_token="fake-token")):
+        with (
+            patch.object(mod, "BangumiClient", return_value=mock_client),
+            patch.object(mod, "config", MagicMock(bangumi_token="fake-token")),
+        ):
             result = await mod.run(subject_id="517057", comment="Great anime!")
 
         assert "Collection updated for subject 517057" in result

--- a/tests/core/rss/filter/test_regex.py
+++ b/tests/core/rss/filter/test_regex.py
@@ -31,13 +31,28 @@ def _mock_config(exclude_patterns: list[str] | None = None):
 
 class TestRegexTitleFilter:
     @pytest.mark.asyncio
-    async def test_empty_patterns_passes_all(self):
-        """No patterns configured → everything passes."""
+    async def test_default_pattern_excludes_collections(self):
+        """Default pattern should exclude collection-style titles."""
         f = RegexTitleFilter()
-        candidates = [_make_resource("A"), _make_resource("B")]
+        candidates = [
+            _make_resource(
+                "[7³ACG] 岁月流逝饭菜依旧美味/Hibi wa Sugiredo Meshi Umashi S01 | 01-12 [简繁字幕] BDrip 1080p x265 OPUS 2.0"
+            ),
+            _make_resource(
+                "[SweetSub][正相反的你与我][Seihantai na Kimi to Boku][01-12 精校合集][WebRip][1080P][AVC 8bit][简日双语]"
+            ),
+            _make_resource(
+                "[奶活家教压制组][东京喰种√A/东京喰种][Tokyo Ghoul][S01][TV01-12Fin][BDRip][1080p][FLAC][X265]"
+            ),
+            _make_resource(
+                "[云光字幕组]葬送的芙莉莲 第二季 Sousou no Frieren S2 [合集][简体双语][1080p]招募翻译V2"
+            ),
+            _make_resource("[字幕组] 动漫02 - 01"),
+        ]
         with patch(_CFG, _mock_config([])):
             result = f.apply(candidates)
-        assert len(result) == 2
+        assert len(result) == 1
+        assert result[0].title == "[字幕组] 动漫02 - 01"
 
     @pytest.mark.asyncio
     async def test_empty_batch(self):


### PR DESCRIPTION
## Summary
- **修正 strict filter 执行顺序**：将 `PriorityFilter` 移至 `StrictRenameFilter` 之前，确保 strict 模式在优先级排序后的候选项上执行
- **新增默认合集过滤**：在 `RegexTitleFilter` 中增加内置正则 `(\d{2}-\d{2}|合集)`，自动过滤合集类标题（当前不支持合集下载）
- **修正单元测试**：移除过时的 `ep_status` PATCH 测试，统一 `with` 语句语法风格，更新 regex filter 测试以适配新的默认过滤模式

## Test plan
- [ ] 验证 RSS 过滤链在 strict 模式下的执行顺序正确
- [ ] 验证含"合集"或"01-12"样式标题的 RSS 条目被默认过滤
- [ ] 运行全量单元测试确认无回归