### PR TITLE
Fix assistant thinking passback

### DIFF
--- a/src/openlist_ani/assistant/core/loop.py
+++ b/src/openlist_ani/assistant/core/loop.py
@@ -361,6 +361,10 @@ class AgenticLoop:
     def _estimate_message_chars(msg: Message) -> int:
         """Estimate the character count of a message."""
         chars = len(msg.content)
+        if msg.reasoning_content:
+            chars += len(msg.reasoning_content)
+        for tb in msg.thinking_blocks:
+            chars += len(tb.get("thinking", "")) + 50
         for tc in msg.tool_calls:
             chars += len(tc.name) + len(str(tc.arguments)) + 50  # overhead
         for tr in msg.tool_results:
@@ -650,7 +654,12 @@ class AgenticLoop:
             )
             if response.text:
                 self._messages.append(
-                    Message(role=Role.ASSISTANT, content=response.text)
+                    Message(
+                        role=Role.ASSISTANT,
+                        content=response.text,
+                        reasoning_content=response.reasoning_content,
+                        thinking_blocks=response.thinking_blocks,
+                    )
                 )
             return True, ESCALATED_MAX_TOKENS, max_output_tokens_recovery_count
 
@@ -664,7 +673,12 @@ class AgenticLoop:
             )
             if response.text:
                 self._messages.append(
-                    Message(role=Role.ASSISTANT, content=response.text)
+                    Message(
+                        role=Role.ASSISTANT,
+                        content=response.text,
+                        reasoning_content=response.reasoning_content,
+                        thinking_blocks=response.thinking_blocks,
+                    )
                 )
             self._messages.append(
                 Message(
@@ -685,7 +699,12 @@ class AgenticLoop:
         if not response.text:
             return
         self._messages.append(
-            Message(role=Role.ASSISTANT, content=response.text)
+            Message(
+                role=Role.ASSISTANT,
+                content=response.text,
+                reasoning_content=response.reasoning_content,
+                thinking_blocks=response.thinking_blocks,
+            )
         )
         await queue.put(
             LoopEvent(type=EventType.TEXT_DONE, text=response.text)
@@ -693,7 +712,12 @@ class AgenticLoop:
         # Persist to JSONL session storage
         if self._session_storage:
             await self._session_storage.record_message(
-                Message(role=Role.ASSISTANT, content=response.text)
+                Message(
+                    role=Role.ASSISTANT,
+                    content=response.text,
+                    reasoning_content=response.reasoning_content,
+                    thinking_blocks=response.thinking_blocks,
+                )
             )
         # Fire-and-forget: check auto-dream gates (tracked for cleanup)
         if self._auto_dream_runner and self._session_storage:
@@ -767,6 +791,8 @@ class AgenticLoop:
                 role=Role.ASSISTANT,
                 content=response.text,
                 tool_calls=response.tool_calls,
+                reasoning_content=response.reasoning_content,
+                thinking_blocks=response.thinking_blocks,
             )
         )
 

--- a/src/openlist_ani/assistant/core/models.py
+++ b/src/openlist_ani/assistant/core/models.py
@@ -68,6 +68,9 @@ class Message:
     content: str = ""
     tool_calls: list[ToolCall] = field(default_factory=list)
     tool_results: list[ToolResult] = field(default_factory=list)
+    reasoning_content: str | None = None
+    # Anthropic-format thinking blocks (list of {"type": "thinking", "thinking": ..., "signature": ...})
+    thinking_blocks: list[dict] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         d: dict = {"role": self.role.value, "content": self.content}
@@ -75,6 +78,10 @@ class Message:
             d["tool_calls"] = [tc.to_dict() for tc in self.tool_calls]
         if self.tool_results:
             d["tool_results"] = [tr.to_dict() for tr in self.tool_results]
+        if self.reasoning_content is not None:
+            d["reasoning_content"] = self.reasoning_content
+        if self.thinking_blocks:
+            d["thinking_blocks"] = self.thinking_blocks
         return d
 
     @classmethod
@@ -88,6 +95,8 @@ class Message:
             tool_results=[
                 ToolResult.from_dict(tr) for tr in data.get("tool_results", [])
             ],
+            reasoning_content=data.get("reasoning_content"),
+            thinking_blocks=data.get("thinking_blocks", []),
         )
 
 
@@ -99,6 +108,9 @@ class ProviderResponse:
     tool_calls: list[ToolCall] = field(default_factory=list)
     stop_reason: str = ""
     usage: dict[str, int] = field(default_factory=dict)
+    reasoning_content: str | None = None
+    # Anthropic-format thinking blocks for pass-back
+    thinking_blocks: list[dict] = field(default_factory=list)
 
 
 class EventType(str, Enum):

--- a/src/openlist_ani/assistant/core/subagent.py
+++ b/src/openlist_ani/assistant/core/subagent.py
@@ -258,7 +258,13 @@ async def _run_subagent_loop(
 
         # Append assistant message with tool calls
         messages.append(
-            Message(role=Role.ASSISTANT, tool_calls=response.tool_calls, content=response.text)
+            Message(
+                role=Role.ASSISTANT,
+                tool_calls=response.tool_calls,
+                content=response.text,
+                reasoning_content=response.reasoning_content,
+                thinking_blocks=response.thinking_blocks,
+            )
         )
 
         # Execute tool calls via orchestrator (parallel/serial)

--- a/src/openlist_ani/assistant/provider/anthropic_provider.py
+++ b/src/openlist_ani/assistant/provider/anthropic_provider.py
@@ -90,8 +90,36 @@ class AnthropicProvider(Provider):
     ) -> ProviderResponse:
         system_prompt, api_messages = self._convert_messages(messages)
         max_tokens = max_tokens_override or self._default_max_tokens
-        temp = temperature if temperature is not None else DEFAULT_TEMPERATURE
+        kwargs = self._build_request_kwargs(
+            api_messages, max_tokens, temperature, system_prompt, tools
+        )
 
+        response = await self._client.messages.create(**kwargs)
+        text_parts, tool_calls, thinking_blocks = self._parse_response_content(
+            response.content
+        )
+
+        return ProviderResponse(
+            text="\n".join(text_parts),
+            tool_calls=tool_calls,
+            stop_reason=response.stop_reason or "",
+            usage={
+                "prompt_tokens": response.usage.input_tokens,
+                "completion_tokens": response.usage.output_tokens,
+            },
+            thinking_blocks=thinking_blocks,
+        )
+
+    def _build_request_kwargs(
+        self,
+        api_messages: list[dict],
+        max_tokens: int,
+        temperature: float | None,
+        system_prompt: str,
+        tools: list[dict] | None,
+    ) -> dict[str, Any]:
+        """Build kwargs dict for Anthropic message requests."""
+        temp = temperature if temperature is not None else DEFAULT_TEMPERATURE
         kwargs: dict[str, Any] = {
             "model": self._model,
             "messages": api_messages,
@@ -102,40 +130,53 @@ class AnthropicProvider(Provider):
             kwargs["system"] = system_prompt
         if tools:
             kwargs["tools"] = tools
+        return kwargs
 
-        response = await self._client.messages.create(**kwargs)
+    @staticmethod
+    def _thinking_block_to_dict(block: Any) -> dict:
+        """Convert an Anthropic thinking block to a pass-back-safe dict."""
+        if hasattr(block, "model_dump"):
+            return block.model_dump()
+        return {
+            "type": "thinking",
+            "thinking": block.thinking,
+            "signature": getattr(block, "signature", ""),
+        }
 
-        # Parse content blocks
+    @staticmethod
+    def _tool_call_from_block(block: Any) -> ToolCall:
+        """Convert an Anthropic tool_use block to a ToolCall."""
+        return ToolCall(
+            id=block.id,
+            name=block.name,
+            arguments=block.input if isinstance(block.input, dict) else {},
+        )
+
+    @classmethod
+    def _parse_response_content(
+        cls,
+        content: list[Any],
+    ) -> tuple[list[str], list[ToolCall], list[dict]]:
+        """Parse Anthropic content blocks into normalized response fields."""
         text_parts: list[str] = []
         tool_calls: list[ToolCall] = []
+        thinking_blocks: list[dict] = []
 
-        for block in response.content:
-            if block.type == "text":
+        for block in content:
+            if block.type == "thinking":
+                thinking_blocks.append(cls._thinking_block_to_dict(block))
+            elif block.type == "text":
                 text_parts.append(block.text)
             elif block.type == "tool_use":
-                tool_calls.append(
-                    ToolCall(
-                        id=block.id,
-                        name=block.name,
-                        arguments=block.input if isinstance(block.input, dict) else {},
-                    )
-                )
-
-        return ProviderResponse(
-            text="\n".join(text_parts),
-            tool_calls=tool_calls,
-            stop_reason=response.stop_reason or "",
-            usage={
-                "prompt_tokens": response.usage.input_tokens,
-                "completion_tokens": response.usage.output_tokens,
-            },
-        )
+                tool_calls.append(cls._tool_call_from_block(block))
+        return text_parts, tool_calls, thinking_blocks
 
     @staticmethod
     def _handle_block_start(
         event: Any,
         current_block_idx: int,
         current_tool_blocks: dict[int, dict[str, str]],
+        current_thinking_blocks: dict[int, dict[str, str]],
     ) -> int:
         """Handle a content_block_start event. Returns updated block index."""
         current_block_idx += 1
@@ -146,6 +187,11 @@ class AnthropicProvider(Provider):
                 "name": block.name,
                 "input_json": "",
             }
+        elif block.type == "thinking":
+            current_thinking_blocks[current_block_idx] = {
+                "thinking": getattr(block, "thinking", ""),
+                "signature": getattr(block, "signature", ""),
+            }
         return current_block_idx
 
     @staticmethod
@@ -153,6 +199,7 @@ class AnthropicProvider(Provider):
         event: Any,
         current_block_idx: int,
         current_tool_blocks: dict[int, dict[str, str]],
+        current_thinking_blocks: dict[int, dict[str, str]],
     ) -> ProviderResponse | None:
         """Handle a content_block_delta event. Returns a text response or None."""
         delta = event.delta
@@ -160,6 +207,10 @@ class AnthropicProvider(Provider):
             return ProviderResponse(text=delta.text)
         if delta.type == "input_json_delta" and current_block_idx in current_tool_blocks:
             current_tool_blocks[current_block_idx]["input_json"] += delta.partial_json
+        if delta.type == "thinking_delta" and current_block_idx in current_thinking_blocks:
+            current_thinking_blocks[current_block_idx]["thinking"] += getattr(delta, "thinking", "")
+        if delta.type == "signature_delta" and current_block_idx in current_thinking_blocks:
+            current_thinking_blocks[current_block_idx]["signature"] = getattr(delta, "signature", "")
         return None
 
     @staticmethod
@@ -169,14 +220,33 @@ class AnthropicProvider(Provider):
         for block in final.content:
             if block.type != "tool_use":
                 continue
-            tool_calls.append(
-                ToolCall(
-                    id=block.id,
-                    name=block.name,
-                    arguments=block.input if isinstance(block.input, dict) else {},
-                )
-            )
+            tool_calls.append(AnthropicProvider._tool_call_from_block(block))
         return tool_calls
+
+    @staticmethod
+    def _extract_thinking_blocks_from_message(final: Any) -> list[dict]:
+        """Extract thinking blocks from a final Anthropic message."""
+        thinking_blocks: list[dict] = []
+        for block in final.content:
+            if block.type == "thinking":
+                thinking_blocks.append(AnthropicProvider._thinking_block_to_dict(block))
+        return thinking_blocks
+
+    @staticmethod
+    def _build_thinking_blocks_from_tracked(
+        tracked: dict[int, dict[str, str]],
+    ) -> list[dict]:
+        """Build thinking block dicts from stream-tracked data."""
+        blocks: list[dict] = []
+        for data in tracked.values():
+            block: dict[str, str] = {
+                "type": "thinking",
+                "thinking": data["thinking"],
+            }
+            if data.get("signature"):
+                block["signature"] = data["signature"]
+            blocks.append(block)
+        return blocks
 
     async def chat_completion_stream(
         self,
@@ -208,21 +278,36 @@ class AnthropicProvider(Provider):
 
         async with self._client.messages.stream(**kwargs) as stream:
             current_tool_blocks: dict[int, dict[str, str]] = {}
+            current_thinking_blocks: dict[int, dict[str, str]] = {}
             current_block_idx = -1
 
             async for event in stream:
                 if event.type == "content_block_start":
                     current_block_idx = self._handle_block_start(
-                        event, current_block_idx, current_tool_blocks
+                        event, current_block_idx, current_tool_blocks,
+                        current_thinking_blocks,
                     )
                 elif event.type == "content_block_delta":
                     response = self._handle_block_delta(
-                        event, current_block_idx, current_tool_blocks
+                        event, current_block_idx, current_tool_blocks,
+                        current_thinking_blocks,
                     )
                     if response is not None:
                         yield response
 
             final = await stream.get_final_message()
+
+            # Prefer thinking blocks from final message (most complete),
+            # fall back to stream-tracked blocks if final message lacks them
+            thinking_blocks = self._extract_thinking_blocks_from_message(final)
+            if not thinking_blocks and current_thinking_blocks:
+                thinking_blocks = self._build_thinking_blocks_from_tracked(
+                    current_thinking_blocks
+                )
+                logger.debug(
+                    f"Used stream-tracked thinking blocks "
+                    f"({len(thinking_blocks)} blocks)"
+                )
 
             yield ProviderResponse(
                 text="",
@@ -232,6 +317,7 @@ class AnthropicProvider(Provider):
                     "prompt_tokens": final.usage.input_tokens,
                     "completion_tokens": final.usage.output_tokens,
                 },
+                thinking_blocks=thinking_blocks,
             )
 
     def format_tool_definitions(self, tools: list[BaseTool]) -> list[dict]:
@@ -248,6 +334,9 @@ class AnthropicProvider(Provider):
     def _convert_assistant_message(msg: Message) -> dict | None:
         """Convert an assistant Message to an Anthropic API message dict."""
         content_blocks: list[dict[str, Any]] = []
+        # Thinking blocks must come first and be passed back as-is
+        for tb in msg.thinking_blocks:
+            content_blocks.append(tb)
         if msg.content:
             content_blocks.append({"type": "text", "text": msg.content})
         for tc in msg.tool_calls:

--- a/src/openlist_ani/assistant/provider/openai_provider.py
+++ b/src/openlist_ani/assistant/provider/openai_provider.py
@@ -29,8 +29,6 @@ from openlist_ani.assistant.tool.base import BaseTool
 
 from .base import Provider
 
-from loguru import logger
-
 
 def _get_max_tokens_for_model(model: str) -> int:
     """Get model-specific default max_tokens."""
@@ -122,6 +120,10 @@ class OpenAIProvider(Provider):
                     )
                 )
 
+        # Capture reasoning_content for providers that support thinking mode
+        # (e.g. DeepSeek). Must be passed back in subsequent API calls.
+        reasoning_content = getattr(msg, "reasoning_content", None)
+
         return ProviderResponse(
             text=msg.content or "",
             tool_calls=tool_calls,
@@ -130,6 +132,7 @@ class OpenAIProvider(Provider):
                 "prompt_tokens": response.usage.prompt_tokens if response.usage else 0,
                 "completion_tokens": response.usage.completion_tokens if response.usage else 0,
             },
+            reasoning_content=reasoning_content,
         )
 
     @staticmethod
@@ -217,37 +220,89 @@ class OpenAIProvider(Provider):
 
         collected_tool_calls: dict[int, dict[str, str]] = {}
         usage_data: dict[str, int] = {}
+        reasoning_parts: list[str] = []
 
         async for chunk in stream:
-            if chunk.usage:
-                usage_data = {
-                    "prompt_tokens": chunk.usage.prompt_tokens,
-                    "completion_tokens": chunk.usage.completion_tokens,
-                }
+            for response in self._handle_stream_chunk(
+                chunk, collected_tool_calls, usage_data, reasoning_parts
+            ):
+                yield response
 
-            if not chunk.choices:
-                continue
+    def _handle_stream_chunk(
+        self,
+        chunk: Any,
+        collected_tool_calls: dict[int, dict[str, str]],
+        usage_data: dict[str, int],
+        reasoning_parts: list[str],
+    ) -> list[ProviderResponse]:
+        """Update stream state from one chunk and return responses to yield."""
+        self._update_usage_from_chunk(chunk, usage_data)
+        if not chunk.choices:
+            return []
 
-            choice = chunk.choices[0]
-            delta = choice.delta
-
-            if delta and delta.content:
-                yield ProviderResponse(text=delta.content)
-
-            if delta and delta.tool_calls:
-                self._accumulate_tool_call_deltas(
-                    collected_tool_calls, delta.tool_calls
+        choice = chunk.choices[0]
+        delta = choice.delta
+        responses = self._handle_delta(delta, collected_tool_calls, reasoning_parts)
+        if choice.finish_reason:
+            responses.append(
+                self._build_final_stream_response(
+                    choice.finish_reason, collected_tool_calls, usage_data,
+                    reasoning_parts,
                 )
+            )
+        return responses
 
-            if choice.finish_reason:
-                yield ProviderResponse(
-                    text="",
-                    tool_calls=self._build_tool_calls_from_collected(
-                        collected_tool_calls
-                    ),
-                    stop_reason=choice.finish_reason,
-                    usage=usage_data,
-                )
+    @staticmethod
+    def _update_usage_from_chunk(chunk: Any, usage_data: dict[str, int]) -> None:
+        """Mutate usage_data with usage info from a stream chunk, if present."""
+        if not chunk.usage:
+            return
+        usage_data.clear()
+        usage_data.update(
+            {
+                "prompt_tokens": chunk.usage.prompt_tokens,
+                "completion_tokens": chunk.usage.completion_tokens,
+            }
+        )
+
+    def _handle_delta(
+        self,
+        delta: Any,
+        collected_tool_calls: dict[int, dict[str, str]],
+        reasoning_parts: list[str],
+    ) -> list[ProviderResponse]:
+        """Accumulate one stream delta and return immediate text responses."""
+        if delta is None:
+            return []
+
+        responses: list[ProviderResponse] = []
+        delta_reasoning = getattr(delta, "reasoning_content", None)
+        if delta_reasoning:
+            reasoning_parts.append(delta_reasoning)
+        if delta.content:
+            responses.append(ProviderResponse(text=delta.content))
+        if delta.tool_calls:
+            self._accumulate_tool_call_deltas(
+                collected_tool_calls, delta.tool_calls
+            )
+        return responses
+
+    def _build_final_stream_response(
+        self,
+        finish_reason: str,
+        collected_tool_calls: dict[int, dict[str, str]],
+        usage_data: dict[str, int],
+        reasoning_parts: list[str],
+    ) -> ProviderResponse:
+        """Build the final metadata response for a completed stream."""
+        reasoning_content = "".join(reasoning_parts) if reasoning_parts else None
+        return ProviderResponse(
+            text="",
+            tool_calls=self._build_tool_calls_from_collected(collected_tool_calls),
+            stop_reason=finish_reason,
+            usage=usage_data,
+            reasoning_content=reasoning_content,
+        )
 
     def format_tool_definitions(self, tools: list[BaseTool]) -> list[dict]:
         return [
@@ -281,40 +336,58 @@ class OpenAIProvider(Provider):
         api_messages: list[dict] = []
 
         for msg in messages:
-            if msg.role == Role.SYSTEM:
-                api_messages.append({"role": "system", "content": msg.content})
-
-            elif msg.role == Role.USER:
-                api_messages.append({"role": "user", "content": msg.content})
-
-            elif msg.role == Role.ASSISTANT:
-                entry: dict[str, Any] = {"role": "assistant"}
-                if msg.tool_calls:
-                    entry["tool_calls"] = [
-                        {
-                            "id": tc.id,
-                            "type": "function",
-                            "function": {
-                                "name": tc.name,
-                                "arguments": json.dumps(tc.arguments, ensure_ascii=False),
-                            },
-                        }
-                        for tc in msg.tool_calls
-                    ]
-                    # OpenAI requires content to be present (can be null)
-                    entry["content"] = msg.content or None
-                else:
-                    entry["content"] = msg.content
-                api_messages.append(entry)
-
-            elif msg.role == Role.TOOL:
-                for result in msg.tool_results:
-                    api_messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": result.tool_call_id,
-                            "content": result.content,
-                        }
-                    )
+            api_messages.extend(self._convert_message(msg))
 
         return api_messages
+
+    def _convert_message(self, msg: Message) -> list[dict]:
+        """Convert a single internal Message to OpenAI API message(s)."""
+        if msg.role in (Role.SYSTEM, Role.USER):
+            return [{"role": msg.role.value, "content": msg.content}]
+        if msg.role == Role.ASSISTANT:
+            return [self._convert_assistant_message(msg)]
+        if msg.role == Role.TOOL:
+            return self._convert_tool_message(msg)
+        return []
+
+    @staticmethod
+    def _convert_assistant_message(msg: Message) -> dict:
+        """Convert an assistant Message to an OpenAI API message."""
+        entry: dict[str, Any] = {"role": "assistant"}
+        if msg.tool_calls:
+            entry["tool_calls"] = [
+                OpenAIProvider._format_tool_call(tc) for tc in msg.tool_calls
+            ]
+            # OpenAI requires content to be present (can be null)
+            entry["content"] = msg.content or None
+        else:
+            entry["content"] = msg.content
+        # Pass back reasoning_content for providers that require it
+        # (e.g. DeepSeek thinking mode). Must be included even if empty string.
+        if msg.reasoning_content is not None:
+            entry["reasoning_content"] = msg.reasoning_content
+        return entry
+
+    @staticmethod
+    def _format_tool_call(tc: ToolCall) -> dict:
+        """Convert a ToolCall to OpenAI function-call format."""
+        return {
+            "id": tc.id,
+            "type": "function",
+            "function": {
+                "name": tc.name,
+                "arguments": json.dumps(tc.arguments, ensure_ascii=False),
+            },
+        }
+
+    @staticmethod
+    def _convert_tool_message(msg: Message) -> list[dict]:
+        """Convert a tool Message to OpenAI API message(s)."""
+        return [
+            {
+                "role": "tool",
+                "tool_call_id": result.tool_call_id,
+                "content": result.content,
+            }
+            for result in msg.tool_results
+        ]

--- a/tests/assistant/conftest.py
+++ b/tests/assistant/conftest.py
@@ -80,6 +80,9 @@ class MockProvider(Provider):
         yield ProviderResponse(
             tool_calls=response.tool_calls,
             stop_reason=response.stop_reason or "stop",
+            usage=response.usage,
+            reasoning_content=response.reasoning_content,
+            thinking_blocks=response.thinking_blocks,
         )
 
     def format_tool_definitions(self, tools: list[BaseTool]) -> list[dict]:

--- a/tests/assistant/test_loop.py
+++ b/tests/assistant/test_loop.py
@@ -98,6 +98,35 @@ class TestAgenticLoop:
         assert EventType.TOOL_END in types
 
     @pytest.mark.asyncio
+    async def test_tool_call_round_preserves_thinking_blocks(self, memory, registry):
+        """Thinking blocks must be kept on assistant tool-use messages."""
+        thinking_block = {
+            "type": "thinking",
+            "thinking": "I need to search first.",
+            "signature": "sig_123",
+        }
+        provider = MockProvider([
+            ProviderResponse(
+                tool_calls=[ToolCall(id="tc_1", name="grep", arguments={})],
+                thinking_blocks=[thinking_block],
+            ),
+            ProviderResponse(text="Found the results."),
+        ])
+        context = ContextBuilder(memory)
+        loop = AgenticLoop(provider, registry, context, memory)
+
+        results = []
+        async for event in loop.process("Search for something"):
+            results.append(event)
+
+        assistant_tool_messages = [
+            msg for msg in loop._messages
+            if msg.role == Role.ASSISTANT and msg.tool_calls
+        ]
+        assert _collect_text(results) == "Found the results."
+        assert assistant_tool_messages[0].thinking_blocks == [thinking_block]
+
+    @pytest.mark.asyncio
     async def test_multi_round_tool_calls(self, memory, registry):
         """Multiple rounds of tool calls before final text."""
         provider = MockProvider([

--- a/tests/assistant/test_provider.py
+++ b/tests/assistant/test_provider.py
@@ -104,6 +104,29 @@ class TestAnthropicProvider:
         assert content[1]["type"] == "tool_use"
         assert content[1]["name"] == "read"
 
+    def test_convert_messages_assistant_passes_back_thinking_before_tool_use(self):
+        provider = AnthropicProvider(api_key="test", base_url="https://test.example.com", model="claude")
+        thinking_block = {
+            "type": "thinking",
+            "thinking": "I should inspect the file.",
+            "signature": "sig_123",
+        }
+        tc = ToolCall(id="tc_1", name="read", arguments={"path": "/home/user/data"})
+        messages = [
+            Message(
+                role=Role.ASSISTANT,
+                content="Let me read that.",
+                tool_calls=[tc],
+                thinking_blocks=[thinking_block],
+            )
+        ]
+        _, api_messages = provider._convert_messages(messages)
+
+        content = api_messages[0]["content"]
+        assert content[0] == thinking_block
+        assert content[1]["type"] == "text"
+        assert content[2]["type"] == "tool_use"
+
     def test_convert_messages_tool_results_as_user(self):
         provider = AnthropicProvider(api_key="test", base_url="https://test.example.com", model="claude")
         tr = ToolResult(tool_call_id="tc_1", name="read", content="file data")


### PR DESCRIPTION
## Summary
- preserve Anthropic thinking blocks and OpenAI-compatible reasoning content in assistant history
- pass thinking blocks back before tool_use blocks for Anthropic thinking mode
- add regression coverage for provider conversion and agent loop streaming metadata

## Tests
- uv run pytest tests/assistant -q