### PR TITLE
fix(persistence): reuse legacy resources table

### DIFF
--- a/src/openlist_ani/adapters/outbound/persistence/sqlite_anime_library_repository.py
+++ b/src/openlist_ani/adapters/outbound/persistence/sqlite_anime_library_repository.py
@@ -18,9 +18,9 @@ class SqliteAnimeLibraryRepository:
 
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute("""
-                CREATE TABLE IF NOT EXISTS anime_library_entries (
+                CREATE TABLE IF NOT EXISTS resources (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    url TEXT UNIQUE NOT NULL,
+                    url TEXT NOT NULL,
                     title TEXT UNIQUE NOT NULL,
                     anime_name TEXT,
                     season INTEGER,
@@ -32,12 +32,10 @@ class SqliteAnimeLibraryRepository:
                     downloaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
                 """)
-            await db.execute(
-                "CREATE INDEX IF NOT EXISTS idx_title ON anime_library_entries(title)"
-            )
+            await db.execute("CREATE INDEX IF NOT EXISTS idx_title ON resources(title)")
             await db.execute(
                 "CREATE INDEX IF NOT EXISTS idx_anime_episode "
-                "ON anime_library_entries(anime_name, season, episode)"
+                "ON resources(anime_name, season, episode)"
             )
             await db.commit()
 
@@ -45,7 +43,7 @@ class SqliteAnimeLibraryRepository:
         """Check if a release has already been ingested based on title."""
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute(
-                "SELECT 1 FROM anime_library_entries WHERE title = ?", (title,)
+                "SELECT 1 FROM resources WHERE title = ?", (title,)
             )
             row = await cursor.fetchone()
             return row is not None
@@ -70,7 +68,7 @@ class SqliteAnimeLibraryRepository:
             db.row_factory = aiosqlite.Row
             cursor = await db.execute(
                 "SELECT fansub, quality, languages, version "
-                "FROM anime_library_entries "
+                "FROM resources "
                 "WHERE anime_name = ? AND season = ? AND episode = ?",
                 (anime_name, season, episode),
             )
@@ -81,7 +79,7 @@ class SqliteAnimeLibraryRepository:
         """Remove a library entry by title."""
         async with aiosqlite.connect(self.db_path) as conn:
             await conn.execute(
-                "DELETE FROM anime_library_entries WHERE title = ?",
+                "DELETE FROM resources WHERE title = ?",
                 (title,),
             )
             await conn.commit()
@@ -99,7 +97,7 @@ class SqliteAnimeLibraryRepository:
 
                 await db.execute(
                     """
-                    INSERT OR IGNORE INTO anime_library_entries
+                    INSERT OR IGNORE INTO resources
                     (
                         url,
                         title,

--- a/tests/adapters/outbound/persistence/test_sqlite_anime_library_repository.py
+++ b/tests/adapters/outbound/persistence/test_sqlite_anime_library_repository.py
@@ -1,5 +1,7 @@
 """Tests for SqliteAnimeLibraryQueryAdapter SQL keyword filtering."""
 
+import sqlite3
+
 import pytest
 
 from openlist_ani.adapters.outbound.persistence import (
@@ -24,10 +26,10 @@ class TestExecuteSqlQueryKeywordFilter:
     @pytest.mark.parametrize(
         "sql",
         [
-            "SELECT 1; DROP TABLE anime_library_entries",
-            "SELECT 1 FROM anime_library_entries; DELETE FROM anime_library_entries",
-            "SELECT 1; INSERT INTO anime_library_entries(url, title) VALUES('a', 'b')",
-            "SELECT 1; UPDATE anime_library_entries SET title='x'",
+            "SELECT 1; DROP TABLE resources",
+            "SELECT 1 FROM resources; DELETE FROM resources",
+            "SELECT 1; INSERT INTO resources(url, title) VALUES('a', 'b')",
+            "SELECT 1; UPDATE resources SET title='x'",
         ],
     )
     async def test_blocks_dangerous_write_keywords(
@@ -41,7 +43,7 @@ class TestExecuteSqlQueryKeywordFilter:
     ) -> None:
         """'created_at' contains 'create' as a substring — must NOT be blocked."""
         result = await test_db.execute_sql_query(
-            "SELECT 1 AS created_at FROM anime_library_entries"
+            "SELECT 1 AS created_at FROM resources"
         )
         # Should succeed (not trigger false positive)
         assert result != [{"error": "Query contains dangerous keywords"}]
@@ -51,7 +53,7 @@ class TestExecuteSqlQueryKeywordFilter:
     ) -> None:
         """'updated_at' contains 'update' as a substring — must NOT be blocked."""
         result = await test_db.execute_sql_query(
-            "SELECT 1 AS updated_at FROM anime_library_entries"
+            "SELECT 1 AS updated_at FROM resources"
         )
         assert result != [{"error": "Query contains dangerous keywords"}]
 
@@ -60,23 +62,61 @@ class TestExecuteSqlQueryKeywordFilter:
     ) -> None:
         """Words like 'raindrop' or 'backdrop' must NOT be blocked."""
         result = await test_db.execute_sql_query(
-            "SELECT * FROM anime_library_entries WHERE title LIKE '%raindrop%'"
+            "SELECT * FROM resources WHERE title LIKE '%raindrop%'"
         )
         assert result != [{"error": "Query contains dangerous keywords"}]
 
     async def test_rejects_non_select(
         self, test_db: SqliteAnimeLibraryQueryAdapter
     ) -> None:
-        result = await test_db.execute_sql_query(
-            "INSERT INTO anime_library_entries VALUES(1)"
-        )
+        result = await test_db.execute_sql_query("INSERT INTO resources VALUES(1)")
         assert result == [{"error": "Only SELECT queries are allowed"}]
 
     async def test_valid_select_works(
         self, test_db: SqliteAnimeLibraryQueryAdapter
     ) -> None:
         result = await test_db.execute_sql_query(
-            "SELECT COUNT(*) as cnt FROM anime_library_entries"
+            "SELECT COUNT(*) as cnt FROM resources"
         )
         assert len(result) == 1
         assert result[0]["cnt"] == 0
+
+
+async def test_repository_reuses_existing_resources_table(tmp_path):
+    db_path = tmp_path / "data.db"
+    title = "[ANi] Already Downloaded - 01 [1080P]"
+    with sqlite3.connect(db_path) as db:
+        db.execute("""
+            CREATE TABLE resources (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                url TEXT NOT NULL,
+                title TEXT UNIQUE NOT NULL,
+                anime_name TEXT,
+                season INTEGER,
+                episode INTEGER,
+                fansub TEXT,
+                quality TEXT,
+                languages TEXT,
+                version INTEGER,
+                downloaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        db.execute(
+            "INSERT INTO resources (url, title) VALUES (?, ?)",
+            ("magnet:?xt=urn:btih:test", title),
+        )
+        db.commit()
+
+    repository = SqliteAnimeLibraryRepository(db_path=db_path)
+    await repository.init()
+
+    assert await repository.is_downloaded(title)
+    with sqlite3.connect(db_path) as db:
+        tables = {
+            row[0]
+            for row in db.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+    assert "resources" in tables
+    assert "anime_library_entries" not in tables

--- a/tests/assistant/test_resource_cleanup.py
+++ b/tests/assistant/test_resource_cleanup.py
@@ -81,7 +81,7 @@ class TestProviderClose:
 
 
 class TestAgenticLoopShutdown:
-    """Verify that AgenticLoop.shutdown() cleans up anime_library_entries."""
+    """Verify that AgenticLoop.shutdown() cleans up resources."""
 
     def _make_loop(
         self,


### PR DESCRIPTION
## Summary
- Reuse the legacy resources table for anime library persistence
- Avoid creating anime_library_entries so existing production data remains readable
- Add regression coverage for existing resources-table databases

## Test Plan
- uv run ruff format --check .
- uv run ruff check .
- uv run pytest