### PR TITLE
ci: add pull request quality gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(actions)"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(docker)"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+## Background
+
+<!-- Explain why this change is needed: related issue, production problem, user need, technical debt, or context. -->
+
+## Description
+
+<!-- Briefly describe what this PR changes. -->
+
+## Detailed Plan
+
+<!-- Describe the implementation approach, key tradeoffs, affected areas, and alternatives that were considered but not used. -->
+
+## Testing and Verification
+
+<!-- List the commands actually run and their results, for example: uv run pytest -q, uv run ruff check . -->
+
+- [ ] Required automated tests were run
+- [ ] Required static checks were run
+- [ ] Changes involving external services, configuration, or secrets were verified in a safe environment
+
+## Configuration and Documentation
+
+<!-- Document configuration, environment variable, deployment, or documentation changes. Write "N/A" if not applicable. -->
+
+- [ ] Relevant documentation was updated, or no documentation update is needed
+- [ ] Example configuration is consistent with actual configuration options
+
+## Compatibility and Risk
+
+<!-- Describe breaking changes, data migrations, performance impact, rollback steps, or rollout notes. -->
+
+- [ ] Backward compatibility was assessed
+- [ ] Main risks and rollback steps were documented
+
+## Screenshots or Logs
+
+<!-- UI screenshots, CLI output, key logs, or runtime evidence. Write "N/A" if not applicable. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - "**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: CI / Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install Python
+        run: uv python install 3.11
+
+      - name: Check lockfile
+        run: uv lock --check
+
+      - name: Run Ruff
+        run: uv run --frozen ruff check .
+
+  test:
+    name: CI / Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install Python
+        run: uv python install 3.11
+
+      - name: Run tests
+        run: uv run --frozen pytest -q
+
+  build:
+    name: CI / Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install Python
+        run: uv python install 3.11
+
+      - name: Build package
+        run: uv build --out-dir dist
+
+      - name: Build Docker image
+        run: docker build --file docker/Dockerfile --tag openlist-ani:ci .


### PR DESCRIPTION
## Background

The repository now requires automated PR gates on `master`, but the CI workflow and PR metadata files need to exist on the default branch before dependency and formatting PRs can use them reliably.

## Description

Adds the initial GitHub Actions CI workflow, a PR template, and Dependabot configuration.

## Detailed Plan

- Add `CI / Lint` with lockfile and Ruff checks.
- Add `CI / Test` with the full pytest suite.
- Add `CI / Build` with Python package and Docker image builds.
- Add a PR template with background, description, detailed plan, validation, documentation, risk, and evidence sections.
- Add Dependabot version update configuration for GitHub Actions, uv, and Docker.

Black formatting enforcement is intentionally left for a follow-up PR after the one-time formatting sweep.

## Testing and Verification

- `uv run --frozen python -c "import yaml; [yaml.safe_load(open(path, encoding='utf-8')) for path in ['.github/workflows/ci.yml', '.github/dependabot.yml']]; print('YAML OK')"` -> passed
- `uv lock --check` -> passed
- `uv run --frozen ruff check .` -> passed
- `uv run --frozen pytest -q` -> 658 passed
- `uv build --out-dir /tmp/openlist-ani-ci-bootstrap-build` -> passed
- `docker build --file docker/Dockerfile --tag openlist-ani:ci-bootstrap .` -> passed

## Configuration and Documentation

Adds repository automation configuration only. No runtime configuration changes.

## Compatibility and Risk

Low risk. The workflow adds automated gates and does not change application behavior.

## Screenshots or Logs

N/A
