### PR TITLE
chore: reduce dependabot update noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,9 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Shanghai"
-    open-pull-requests-limit: 5
+    # Disable routine version update PRs. Dependabot security update PRs
+    # are still controlled by the repository security setting.
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "github-actions"
@@ -21,7 +23,9 @@ updates:
       day: "monday"
       time: "09:30"
       timezone: "Asia/Shanghai"
-    open-pull-requests-limit: 5
+    # Disable routine version update PRs. Dependabot security update PRs
+    # are still controlled by the repository security setting.
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "python"
@@ -35,7 +39,9 @@ updates:
       day: "monday"
       time: "10:00"
       timezone: "Asia/Shanghai"
-    open-pull-requests-limit: 5
+    # Disable routine version update PRs. Dependabot security update PRs
+    # are still controlled by the repository security setting.
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "docker"


### PR DESCRIPTION
## Background

Routine Dependabot version update PRs are too noisy for this repository. Security updates should still be surfaced automatically.

## Description

Disables routine Dependabot version update PRs by setting `open-pull-requests-limit: 0` for GitHub Actions, uv, and Docker ecosystems.

## Detailed Plan

Dependabot security update PRs remain enabled through the repository security setting. Performance-oriented updates are not reliably classified by Dependabot, so those should be handled manually when release notes indicate a meaningful improvement.

## Testing and Verification

- `uv run --frozen python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml', encoding='utf-8')); print('YAML OK')"` -> passed

## Configuration and Documentation

Changes Dependabot configuration only.

## Compatibility and Risk

Low risk. This reduces routine PR volume and does not affect runtime behavior.

## Screenshots or Logs

N/A
