### PR TITLE
style: apply black formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run Ruff
         run: uv run --frozen ruff check .
 
+      - name: Check formatting
+        run: uv run --frozen black --check .
+
   test:
     name: CI / Test
     runs-on: ubuntu-latest

--- a/src/openlist_ani/adapters/inbound/http/router.py
+++ b/src/openlist_ani/adapters/inbound/http/router.py
@@ -32,7 +32,9 @@ router = APIRouter(prefix="/api")
 async def restart_service() -> RestartResponse:
     """Restart the application by sending SIGHUP to self."""
     logger.debug("Backend: Restart requested via API")
-    os.kill(os.getpid(), signal.SIGHUP)  # noqa: S603 – intentional self-signal for graceful restart
+    os.kill(
+        os.getpid(), signal.SIGHUP
+    )  # noqa: S603 – intentional self-signal for graceful restart
     return RestartResponse(success=True, message="Restart signal sent")
 
 

--- a/src/openlist_ani/adapters/outbound/configuration/settings.py
+++ b/src/openlist_ani/adapters/outbound/configuration/settings.py
@@ -32,9 +32,7 @@ class PriorityConfig(BaseModel):
     fansub: list[str] = Field(
         default_factory=list
     )  # Fansub group priority, e.g. ["Fansub_A", "Fansub_B"]
-    languages: list[str] = Field(
-        default_factory=list
-    )  # Language priority labels
+    languages: list[str] = Field(default_factory=list)  # Language priority labels
     quality: list[str] = Field(
         default_factory=lambda: ["2160p", "1080p", "720p", "480p"]
     )  # Quality priority (high to low); set to [] to disable
@@ -47,9 +45,7 @@ class MetadataFilterConfig(BaseModel):
     metadata matches any value in the corresponding list is filtered out.
     """
 
-    exclude_fansub: list[str] = Field(
-        default_factory=list
-    )  # Fansub groups to exclude
+    exclude_fansub: list[str] = Field(default_factory=list)  # Fansub groups to exclude
     exclude_quality: list[str] = Field(
         default_factory=list
     )  # Quality values to exclude, e.g. ["480p"]
@@ -64,7 +60,9 @@ class MetadataFilterConfig(BaseModel):
 class RSSConfig(BaseModel):
     urls: list[str] = Field(default_factory=list)
     interval_time: int = 300  # RSS fetch interval in seconds (default: 5 minutes)
-    strict: bool = False  # Strict mode: filter entries whose rename stem matches existing downloads
+    strict: bool = (
+        False  # Strict mode: filter entries whose rename stem matches existing downloads
+    )
     filter: MetadataFilterConfig = MetadataFilterConfig()
     priority: PriorityConfig = PriorityConfig()
 
@@ -122,7 +120,9 @@ class NotificationConfig(BaseModel):
     """Configuration for notification system."""
 
     enabled: bool = False
-    batch_interval: float = 300.0  # Batch notifications interval in seconds (default: 5 minutes, 0 to disable)
+    batch_interval: float = (
+        300.0  # Batch notifications interval in seconds (default: 5 minutes, 0 to disable)
+    )
     bots: list[BotConfig] = Field(default_factory=list)
 
 
@@ -189,7 +189,9 @@ class LogConfig(BaseModel):
     """Configuration for logging."""
 
     level: str = "INFO"  # Log level: DEBUG, INFO, WARNING, ERROR, FATAL
-    rotation: str = "00:00"  # Log rotation time (e.g., "00:00" for midnight, "500 MB" for size-based)
+    rotation: str = (
+        "00:00"  # Log rotation time (e.g., "00:00" for midnight, "500 MB" for size-based)
+    )
     retention: str = "1 week"  # How long to keep old logs
 
 

--- a/src/openlist_ani/adapters/outbound/configuration/validator.py
+++ b/src/openlist_ani/adapters/outbound/configuration/validator.py
@@ -169,7 +169,9 @@ class ConfigValidator:
         _warnings: list[str],
     ) -> None:
         hint = "Run openlist-ani-wechat-login and copy the printed config."
-        self._require_bot_config(bot_label, bot_cfg, "account_id", "WeChat", errors, hint)
+        self._require_bot_config(
+            bot_label, bot_cfg, "account_id", "WeChat", errors, hint
+        )
         self._require_bot_config(bot_label, bot_cfg, "token", "WeChat", errors, hint)
         if bot_cfg.config.get("chat_id") or bot_cfg.config.get("home_channel"):
             return
@@ -258,7 +260,9 @@ class ConfigValidator:
         wechat_cfg = self._data.assistant.wechat
         hint = "Run openlist-ani-wechat-login and copy the printed config."
         if not wechat_cfg.account_id:
-            errors.append(f"WeChat assistant is enabled but account_id is missing. {hint}")
+            errors.append(
+                f"WeChat assistant is enabled but account_id is missing. {hint}"
+            )
         if not wechat_cfg.token:
             errors.append(f"WeChat assistant is enabled but token is missing. {hint}")
         if not wechat_cfg.home_channel:

--- a/src/openlist_ani/adapters/outbound/downloaders/registry.py
+++ b/src/openlist_ani/adapters/outbound/downloaders/registry.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 
 from openlist_ani.application.anime_library_ingestion.ports import DownloaderPort
 
-
 DownloaderFactory = Callable[[], DownloaderPort]
 
 

--- a/src/openlist_ani/adapters/outbound/feed_sources/registry.py
+++ b/src/openlist_ani/adapters/outbound/feed_sources/registry.py
@@ -6,7 +6,6 @@ from urllib.parse import urlparse
 
 from .feed_source import FeedSource
 
-
 FeedSourceFactoryFn = Callable[[], FeedSource]
 
 

--- a/src/openlist_ani/adapters/outbound/file_renamers/registry.py
+++ b/src/openlist_ani/adapters/outbound/file_renamers/registry.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 
 from openlist_ani.application.anime_library_ingestion.ports import FileRenamerPort
 
-
 FileRenamerFactory = Callable[[], FileRenamerPort]
 
 

--- a/src/openlist_ani/adapters/outbound/metadata_parser/registry.py
+++ b/src/openlist_ani/adapters/outbound/metadata_parser/registry.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 
 from openlist_ani.application.anime_library_ingestion.ports import MetadataParserPort
 
-
 MetadataParserFactory = Callable[[], MetadataParserPort]
 
 

--- a/src/openlist_ani/adapters/outbound/notifications/bot/registry.py
+++ b/src/openlist_ani/adapters/outbound/notifications/bot/registry.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from .base import BotBase
 
-
 BotBuilder = Callable[[dict[str, Any]], BotBase]
 
 

--- a/src/openlist_ani/application/anime_library_ingestion/models.py
+++ b/src/openlist_ani/application/anime_library_ingestion/models.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, Field
 from openlist_ani.domain.anime_release import AnimeRelease, LanguageType, VideoQuality
 from openlist_ani.domain.download_task.downloader import DownloaderMemento
 
-
 PayloadT = TypeVar("PayloadT")
 
 

--- a/src/openlist_ani/assistant/__init__.py
+++ b/src/openlist_ani/assistant/__init__.py
@@ -72,7 +72,9 @@ def _validate_wechat_frontend_config(wechat_cfg: Any) -> list[str]:
     if not wechat_cfg.token:
         errors.append(f"WeChat assistant is enabled but token is missing. {hint}")
     if not wechat_cfg.home_channel:
-        errors.append(f"WeChat assistant is enabled but home_channel is missing. {hint}")
+        errors.append(
+            f"WeChat assistant is enabled but home_channel is missing. {hint}"
+        )
     return errors
 
 

--- a/src/openlist_ani/assistant/frontend/messaging.py
+++ b/src/openlist_ani/assistant/frontend/messaging.py
@@ -173,7 +173,9 @@ class MessagingFrontend(Frontend):
                 await loop.session_storage.start_new_session(
                     metadata=self._session_metadata(message)
                 )
-            await self._messenger.send_text(message.target.chat_id, "New session started.")
+            await self._messenger.send_text(
+                message.target.chat_id, "New session started."
+            )
             return True
 
         if text.startswith("/") and await self._handle_skill_command(message):

--- a/src/openlist_ani/builtin_skills/skills/anime-recommend/script/default.py
+++ b/src/openlist_ani/builtin_skills/skills/anime-recommend/script/default.py
@@ -36,7 +36,6 @@ from openlist_ani.assistant.skill_support.anime_recommend_scoring import (
 from openlist_ani.assistant.skill_support.bangumi_client import BangumiClient
 from openlist_ani.assistant.skill_support.bangumi_model import UserCollectionEntry
 
-
 # ------------------------------------------------------------------ #
 # Path helpers
 # ------------------------------------------------------------------ #

--- a/src/openlist_ani/builtin_skills/skills/oani/script/create_download.py
+++ b/src/openlist_ani/builtin_skills/skills/oani/script/create_download.py
@@ -2,7 +2,9 @@
 
 from openlist_ani.assistant.skill_support.oani_backend_client import BackendClient
 from openlist_ani.adapters.outbound.configuration import config
-from openlist_ani.assistant.skill_support.library_query import SqliteAnimeLibraryQueryAdapter
+from openlist_ani.assistant.skill_support.library_query import (
+    SqliteAnimeLibraryQueryAdapter,
+)
 
 
 async def _url_already_in_library(download_url: str) -> dict | None:

--- a/src/openlist_ani/builtin_skills/skills/oani/script/query_library.py
+++ b/src/openlist_ani/builtin_skills/skills/oani/script/query_library.py
@@ -1,6 +1,8 @@
 """Query the anime resource database with SQL SELECT queries."""
 
-from openlist_ani.assistant.skill_support.library_query import SqliteAnimeLibraryQueryAdapter
+from openlist_ani.assistant.skill_support.library_query import (
+    SqliteAnimeLibraryQueryAdapter,
+)
 
 
 async def run(

--- a/src/openlist_ani/integrations/messaging/feishu.py
+++ b/src/openlist_ani/integrations/messaging/feishu.py
@@ -44,7 +44,9 @@ def _read_field(value: Any, key: str, default: Any = None) -> Any:
 
 def _sender_user_id(sender: Any) -> str:
     sender_id = _read_field(sender, "sender_id", {}) or {}
-    return str(_read_field(sender_id, "open_id") or _read_field(sender_id, "user_id") or "")
+    return str(
+        _read_field(sender_id, "open_id") or _read_field(sender_id, "user_id") or ""
+    )
 
 
 def _strip_mentions(text: str, mentions: list[Any]) -> str:
@@ -174,7 +176,9 @@ class FeishuMessenger:
         target_receive_id = receive_id
         target_type = receive_id_type
         if not target_receive_id:
-            target = self.store.load_notification_target("feishu") if self.store else None
+            target = (
+                self.store.load_notification_target("feishu") if self.store else None
+            )
             if target:
                 target_receive_id = target.chat_id
                 target_type = target.receive_id_type
@@ -190,7 +194,9 @@ class FeishuMessenger:
                 CreateMessageRequestBody,
             )
         except ImportError as exc:
-            raise RuntimeError("Feishu messaging requires the lark-oapi package") from exc
+            raise RuntimeError(
+                "Feishu messaging requires the lark-oapi package"
+            ) from exc
 
         request = (
             CreateMessageRequest.builder()
@@ -221,7 +227,9 @@ class FeishuMessenger:
         try:
             import lark_oapi as lark
         except ImportError as exc:
-            raise RuntimeError("Feishu messaging requires the lark-oapi package") from exc
+            raise RuntimeError(
+                "Feishu messaging requires the lark-oapi package"
+            ) from exc
 
         self._sdk_client = (
             lark.Client.builder()
@@ -347,9 +355,9 @@ class FeishuMessenger:
     def _build_lark_event_handler(
         self, dispatcher_handler: Any, on_message: Callable[[Any], None]
     ) -> Any:
-        builder = dispatcher_handler.builder(
-            "", ""
-        ).register_p2_im_message_receive_v1(on_message)
+        builder = dispatcher_handler.builder("", "").register_p2_im_message_receive_v1(
+            on_message
+        )
         if hasattr(builder, "register_p2_im_message_message_read_v1"):
             builder = builder.register_p2_im_message_message_read_v1(
                 _ignore_message_read

--- a/src/openlist_ani/integrations/messaging/wechat_ilink.py
+++ b/src/openlist_ani/integrations/messaging/wechat_ilink.py
@@ -175,7 +175,9 @@ def _extract_text(item_list: list[dict[str, Any]]) -> str:
     return "\n".join(parts).strip()
 
 
-def parse_inbound_message(raw: dict[str, Any], *, account_id: str) -> InboundMessage | None:
+def parse_inbound_message(
+    raw: dict[str, Any], *, account_id: str
+) -> InboundMessage | None:
     sender_id = str(raw.get("from_user_id") or "").strip()
     if not sender_id or sender_id == account_id:
         return None

--- a/tests/_meta/test_architecture_boundaries.py
+++ b/tests/_meta/test_architecture_boundaries.py
@@ -1,7 +1,6 @@
 import ast
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 SRC = ROOT / "src" / "openlist_ani"
 

--- a/tests/_meta/test_layering.py
+++ b/tests/_meta/test_layering.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 
 

--- a/tests/adapters/outbound/feed_sources/test_subscription_reader.py
+++ b/tests/adapters/outbound/feed_sources/test_subscription_reader.py
@@ -34,9 +34,7 @@ async def test_entries_from_multiple_feeds_are_merged():
     mock_handler = AsyncMock()
     mock_handler.fetch_feed = AsyncMock(side_effect=[[r1], [r2]])
 
-    with (
-        patch.object(reader, "_get_feed_source", return_value=mock_handler),
-    ):
+    with (patch.object(reader, "_get_feed_source", return_value=mock_handler),):
         result = await reader.fetch_new_releases()
 
     assert {entry.title for entry in result} == {"Anime A - 01", "Anime B - 01"}
@@ -53,9 +51,7 @@ async def test_entries_without_download_url_are_skipped():
     mock_handler = AsyncMock()
     mock_handler.fetch_feed = AsyncMock(return_value=[release_no_url, release_good])
 
-    with (
-        patch.object(reader, "_get_feed_source", return_value=mock_handler),
-    ):
+    with (patch.object(reader, "_get_feed_source", return_value=mock_handler),):
         result = await reader.fetch_new_releases()
 
     assert [entry.title for entry in result] == ["Good Anime - 01"]
@@ -66,9 +62,7 @@ async def test_fetch_exception_does_not_crash():
     mock_handler = AsyncMock()
     mock_handler.fetch_feed = AsyncMock(side_effect=Exception("Network error"))
 
-    with (
-        patch.object(reader, "_get_feed_source", return_value=mock_handler),
-    ):
+    with (patch.object(reader, "_get_feed_source", return_value=mock_handler),):
         result = await reader.fetch_new_releases()
 
     assert result == []

--- a/tests/assistant/test_loop.py
+++ b/tests/assistant/test_loop.py
@@ -292,9 +292,9 @@ class TestStreaming:
         types = [e.type for e in results]
         # The mock stream yields a text-only delta first, so we must see
         # at least one TEXT_DELTA before the final TEXT_DONE.
-        assert EventType.TEXT_DELTA in types, (
-            f"Expected TEXT_DELTA in events but got: {types}"
-        )
+        assert (
+            EventType.TEXT_DELTA in types
+        ), f"Expected TEXT_DELTA in events but got: {types}"
         assert EventType.TEXT_DONE in types
 
         # Collect all TEXT_DELTA payloads

--- a/tests/manual_test_script/parser_test.py
+++ b/tests/manual_test_script/parser_test.py
@@ -19,19 +19,21 @@ import asyncio
 import sys
 import time
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-SRC_ROOT = PROJECT_ROOT / "src"
-sys.path.insert(0, str(SRC_ROOT))
-
-import openlist_ani.adapters.outbound.metadata_parser.parser as parser_module  # noqa: E402
-from openlist_ani.adapters.outbound.configuration import config  # noqa: E402
-from openlist_ani.adapters.outbound.metadata_parser.llm.client import OpenAILLMClient  # noqa: E402
-from openlist_ani.application.anime_library_ingestion.models import ParseResult  # noqa: E402
-from openlist_ani.adapters.outbound.metadata_parser.parser import parse_metadata  # noqa: E402
-from openlist_ani.domain.anime_release import (  # noqa: E402
+import openlist_ani.adapters.outbound.metadata_parser.parser as parser_module
+from openlist_ani.adapters.outbound.metadata_parser import (
+    MetadataParserAdapter,
+    MetadataParserSettings,
+)
+from openlist_ani.adapters.outbound.configuration import config
+from openlist_ani.adapters.outbound.metadata_parser.llm.client import (
+    OpenAILLMClient,
+)
+from openlist_ani.application.anime_library_ingestion.models import (
+    ParseResult,
+)
+from openlist_ani.domain.anime_release import (
     AnimeRelease,
     LanguageType,
     VideoQuality,
@@ -224,6 +226,17 @@ def make_entry(title: str) -> AnimeRelease:
     return AnimeRelease(title=title, download_url="magnet:?xt=test")
 
 
+def _metadata_parser_settings() -> MetadataParserSettings:
+    return MetadataParserSettings(
+        provider_type=config.llm.provider_type,
+        api_key=config.llm.openai_api_key,
+        base_url=config.llm.openai_base_url,
+        model=config.llm.openai_model,
+        tmdb_api_key=config.llm.tmdb_api_key,
+        tmdb_language=config.llm.tmdb_language,
+    )
+
+
 def _check_field(
     issues: list[str], expected: Any, actual: Any, label: str, fmt: str = "{}"
 ) -> None:
@@ -322,10 +335,14 @@ async def run_parser_validation(
     print()
 
     entries = [make_entry(tc.title) for tc in cases]
+    parser = MetadataParserAdapter.from_settings(_metadata_parser_settings())
 
     print("  ⏳ Running...")
     t0 = time.monotonic()
-    results = await parse_metadata(entries, batch_size=len(entries))
+    try:
+        results = await parser.parse(entries)
+    finally:
+        await parser.close()
     elapsed = time.monotonic() - t0
     print(f"  ✓ Completed in {elapsed:.1f}s")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,7 +39,10 @@ class TestRSSConfig:
         assert cfg.interval_time == 300
 
     def test_custom_values(self):
-        cfg = RSSConfig(urls=["https://feed.example/rss1", "https://feed.example/rss2"], interval_time=60)
+        cfg = RSSConfig(
+            urls=["https://feed.example/rss1", "https://feed.example/rss2"],
+            interval_time=60,
+        )
         assert len(cfg.urls) == 2
         assert cfg.interval_time == 60
 
@@ -475,9 +478,7 @@ class TestConfigValidation:
         mgr.save()
         assert ConfigValidator(mgr.data, mgr.load_failed).validate() is False
 
-    def test_validate_notification_feishu_target_optional(
-        self, tmp_path, monkeypatch
-    ):
+    def test_validate_notification_feishu_target_optional(self, tmp_path, monkeypatch):
         """Feishu target can be configured later with /set-notify-home."""
         monkeypatch.chdir(tmp_path)
         mgr = ConfigManager("config.toml")


### PR DESCRIPTION
## Background

Black formatting is now part of the PR quality gate, so the existing Python files need to be normalized before the new check can protect future PRs.

## Description

Adds `black --check .` to the CI lint job and applies Black formatting to the current Python codebase. Also removes the manual parser script import-path workaround by importing the real parser adapter directly.

## Detailed Plan

- Run Black across `src` and `tests`.
- Add a Black check to `CI / Lint` after Ruff.
- Replace the manual parser test late imports and `noqa` suppressions with normal imports.

## Testing and Verification

- [x] Required automated tests were run
- [x] Required static checks were run
- [x] Changes involving external services, configuration, or secrets were verified in a safe environment

Commands run locally:

- `uv lock --check`
- `uv run --frozen ruff check .`
- `uv run --frozen black --check .`
- `uv run --frozen python tests/manual_test_script/parser_test.py --help`
- `uv run --frozen pytest -q`
- `uv build --out-dir /tmp/openlist-ani-format-build`
- `docker build --file docker/Dockerfile --tag openlist-ani:ci-format .`

## Configuration and Documentation

- [x] Relevant documentation was updated, or no documentation update is needed
- [x] Example configuration is consistent with actual configuration options

Adds a CI formatting gate; no runtime configuration or documentation changes are required.

## Compatibility and Risk

- [x] Backward compatibility was assessed
- [x] Main risks and rollback steps were documented

This is intended to be behavior-preserving formatting. Rollback is a normal revert of this PR.

## Screenshots or Logs

N/A