### PR TITLE
Resolve collection regex Sonar issues

### DIFF
--- a/src/openlist_ani/domain/anime_release/collection.py
+++ b/src/openlist_ani/domain/anime_release/collection.py
@@ -11,7 +11,7 @@ _COLLECTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"全集"),
     re.compile(r"总集篇"),
     re.compile(r"全套"),
-    re.compile(r"全\s*[0-9一二两三四五六七八九十百]+\s*(?:集|话|卷|季)"),
+    re.compile(r"全\s*[0-9一二三四五六七八九十百两]+\s*(?:集|话|卷|季)"),
     re.compile(r"(?:百度网盘|网盘)?打包下载"),
     re.compile(r"(?i)\bcomplete\b"),
     re.compile(
@@ -24,16 +24,16 @@ _COLLECTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bBATCH\b"),
     re.compile(r"(?i)BD[-\s]*BOX"),
     re.compile(r"(?i)\bTV\s*[+＋]\s*(?:OADs?|OVAs?|Movies?|剧场版)\b"),
-    re.compile(r"(?i)\bSeasons?\s*\d{1,2}\s*[-~–—]\s*\d{1,2}\b"),
-    re.compile(r"(?i)\bS\d{1,2}E\d{1,3}\s*[-~–—]\s*E?\d{1,3}\b"),
+    re.compile(r"(?i)\bSeasons?\s*\d{1,2}\s*[~–—-]\s*\d{1,2}\b"),
+    re.compile(r"(?i)\bS\d{1,2}E\d{1,3}\s*[~–—-]\s*E?\d{1,3}\b"),
     re.compile(r"(?i)\bS(?:eason)?\s*\d{1,2}\s*Complete\b"),
-    re.compile(r"(?i)\b(?:Ep(?:isodes?)?|Eps?)\s*0?\d{1,3}\s*[-~–—]\s*\d{1,3}\b"),
-    re.compile(r"(?<![\dA-Za-z])\d{2,3}\s*[-~–—]\s*\d{2,3}(?!\d)"),
+    re.compile(r"(?i)\b(?:Ep(?:isodes?)?|Eps?)\s*0?\d{1,3}\s*[~–—-]\s*\d{1,3}\b"),
+    re.compile(r"(?<![\dA-Za-z])\d{2,3}\s*[~–—-]\s*\d{2,3}(?!\d)"),
     re.compile(
-        r"(?i)(?<![\dA-Za-z])\d{1,3}\s*[-~–—]\s*\d{1,3}\s*\+\s*(?:OVA|OAD|SP|Movies?|剧场版)"
+        r"(?i)(?<![\dA-Za-z])\d{1,3}\s*[~–—-]\s*\d{1,3}\s*\+\s*(?:OVA|OAD|SP|Movies?|剧场版)"
     ),
-    re.compile(r"(?i)(?<![\dA-Za-z])\d{1,3}\s*[-~–—]\s*\d{1,3}(?=\s*[\[(（])"),
-    re.compile(r"(?i)(?<![\dA-Za-z])\d{1,3}\s*[-~–—]\s*\d{1,3}\s*(?:end|fin|完)"),
+    re.compile(r"(?i)(?<![\dA-Za-z])\d{1,3}\s*[~–—-]\s*\d{1,3}(?=\s*[\[(（])"),
+    re.compile(r"(?i)(?<![\dA-Za-z])\d{1,3}\s*[~–—-]\s*\d{1,3}\s*(?:end|fin|完)"),
 )
 
 


### PR DESCRIPTION
## Background

PR #125 improved collection release detection but SonarCloud reported regex maintainability issues in the newly added collection detector. This follow-up keeps the behavior while resolving those issues.

## Description

- Replace ambiguous regex range separator alternations with Sonar-friendly character classes.
- Keep collection detection behavior unchanged.

## Detailed Plan

The change is intentionally limited to `src/openlist_ani/domain/anime_release/collection.py`. It rewrites the separator patterns used for episode and season ranges so SonarCloud no longer reports regex code smells. The detector API and callers are unchanged.

Alternatives considered but not used: suppressing Sonar issues was rejected because equivalent regex forms are simple and keep the code clearer.

## Testing and Verification

- [x] Required automated tests were run: `uv run pytest tests/adapters/outbound/torrent_metadata/test_resolver.py tests/application/anime_library_ingestion/test_filters.py -q` -> 36 passed; `uv run pytest -q` -> 670 passed.
- [x] Required static checks were run: `uv run ruff check .` -> All checks passed; `uv run black --check --target-version py311 .` -> 265 files unchanged.
- [x] Changes involving external services, configuration, or secrets were verified in a safe environment: no external-service, configuration, or secret changes were introduced.

## Configuration and Documentation

N/A. No configuration, environment variable, deployment, or documentation changes were required.

- [x] Relevant documentation was updated, or no documentation update is needed.
- [x] Example configuration is consistent with actual configuration options.

## Compatibility and Risk

No behavior, API, or configuration change is intended. Risk is limited to regex equivalence; existing collection positive and false-positive tests were rerun. Rollback is reverting this follow-up PR.

- [x] Backward compatibility was assessed.
- [x] Main risks and rollback steps were documented.

## Screenshots or Logs

N/A. Non-UI change; verification evidence is listed above.