### PR TITLE
docs: clarify release tag checkout workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 git clone https://github.com/TwooSix/Openlist-Ani.git
 cd Openlist-Ani
 
-# 推荐切换到最新 release tag；master 为开发分支，不保证稳定
-git checkout v***    # 替换为最新版本号
+# 推荐切换到最新 Release tag；master 为开发分支，不保证稳定
+# Release 版本以 tag 为准
+git fetch --tags
+git checkout tags/v***    # 将 v*** 替换为 Release 页面中的版本号
 
 uv sync --no-dev --frozen
 ```

--- a/docs/快速开始.md
+++ b/docs/快速开始.md
@@ -114,8 +114,10 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 # 1. 克隆仓库
 git clone https://github.com/TwooSix/Openlist-Ani.git && cd Openlist-Ani
 
-# 2. 切换到最新版本（master 为开发分支，不保证稳定）
-git checkout v***    # 替换为最新版本号
+# 2. 切换到最新 Release tag（master 为开发分支，不保证稳定）
+# Release 版本以 tag 为准，不需要存在同名 branch
+git fetch --tags
+git checkout tags/v***    # 将 v*** 替换为 Release 页面中的版本号
 
 # 3. 安装依赖
 uv sync --no-dev --frozen

--- a/docs/源码编译指南.md
+++ b/docs/源码编译指南.md
@@ -39,14 +39,15 @@ cd Openlist-Ani
 
 ### 切换到稳定版本
 
-`master` 分支是开发分支，不保证稳定。建议切换到最新 Release 版本：
+`master` 分支是开发分支，不保证稳定。Release 版本以 tag 为准。建议切换到最新 Release tag：
 
 ```bash
-# 查看所有版本号
-git tag
+# 获取并查看所有版本号
+git fetch --tags
+git tag --sort=-v:refname
 
-# 切换到指定版本（替换为最新版本号）
-git checkout v1.0.0
+# 切换到指定版本（将版本号替换为 Release 页面中的版本号）
+git checkout tags/v1.0.0.dev260426
 ```
 
 ## 第三步：安装依赖
@@ -353,6 +354,6 @@ sudo systemctl enable --now openlist-ani
 ```bash
 cd /path/to/Openlist-Ani
 git fetch --tags
-git checkout v最新版本号
+git checkout tags/v最新版本号
 uv sync --no-dev --frozen
 ```


### PR DESCRIPTION
## 摘要
- 明确源码运行 Release 版本时以 tag 为准，不依赖同名 branch。
- README、快速开始、源码编译指南统一使用 `git checkout tags/v***`。
- 补充 detached HEAD 说明，以及从 tag 新建本地分支的命令。

## 验证
- `git diff --check HEAD~1..HEAD`