### PR TITLE
fix(test): disable file logging during pytest

### DIFF
--- a/src/openlist_ani/assistant/__init__.py
+++ b/src/openlist_ani/assistant/__init__.py
@@ -426,19 +426,21 @@ def main() -> None:
     # to match the assistant's needs.
     from loguru import logger as loguru_logger
 
-    from openlist_ani.logger import LOG_DIR
+    from openlist_ani.logger import LOG_DIR, file_logging_enabled_from_env
 
     loguru_logger.remove()  # Remove all default handlers
 
-    # Dedicated assistant log file (matches legacy "assistant_xxx.log" naming)
-    loguru_logger.add(
-        LOG_DIR / "assistant_{time:YYYY-MM-DD}.log",
-        rotation="00:00",
-        retention="1 week",
-        level="INFO",
-        encoding="utf-8",
-        mode="a",
-    )
+    if file_logging_enabled_from_env():
+        LOG_DIR.mkdir(exist_ok=True)
+        # Dedicated assistant log file (matches legacy "assistant_xxx.log" naming)
+        loguru_logger.add(
+            LOG_DIR / "assistant_{time:YYYY-MM-DD}.log",
+            rotation="00:00",
+            retention="1 week",
+            level="INFO",
+            encoding="utf-8",
+            mode="a",
+        )
 
     # Console handler - only for Telegram mode.
     # CLI mode uses Rich for terminal output; loguru stdout would

--- a/src/openlist_ani/logger.py
+++ b/src/openlist_ani/logger.py
@@ -1,5 +1,6 @@
 import ast
 from functools import lru_cache
+import os
 from pathlib import Path
 import re
 from sys import stdout
@@ -9,7 +10,6 @@ from loguru import logger as _logger
 
 # Configure logging path
 LOG_DIR = Path.cwd() / "logs"
-LOG_DIR.mkdir(exist_ok=True)
 
 FATAL_LEVEL = "FATAL"
 LOG_FORMAT = (
@@ -136,11 +136,19 @@ logger = _logger.patch(_sanitize_record)
 logger.remove()
 
 
+def file_logging_enabled_from_env() -> bool:
+    value = os.getenv("OPENLIST_ANI_FILE_LOGGING")
+    if value is None:
+        return True
+    return value.strip().lower() not in {"0", "false", "no", "off", "disabled"}
+
+
 def configure_logger(
     level: str = "INFO",
     rotation: str = "00:00",
     retention: str = "1 week",
     log_name: str = "openlist_ani",
+    file_logging: bool | None = None,
 ) -> None:
     """Configure logger with given settings.
 
@@ -149,11 +157,11 @@ def configure_logger(
         rotation: Log rotation settings (time like "00:00" or size like "500 MB")
         retention: How long to keep old logs
         log_name: Base name for the log file
+        file_logging: Whether to write logs to files. Defaults to
+            OPENLIST_ANI_FILE_LOGGING when unset.
     """
     # Remove all existing handlers first
     logger.remove()
-
-    log_file = LOG_DIR / f"{log_name}_{{time:YYYY-MM-DD}}.log"
 
     # Add console handler
     logger.add(
@@ -164,6 +172,14 @@ def configure_logger(
         backtrace=False,
         diagnose=False,
     )
+
+    if file_logging is None:
+        file_logging = file_logging_enabled_from_env()
+    if not file_logging:
+        return
+
+    LOG_DIR.mkdir(exist_ok=True)
+    log_file = LOG_DIR / f"{log_name}_{{time:YYYY-MM-DD}}.log"
 
     # Add file handler with rotation and retention
     logger.add(
@@ -187,6 +203,7 @@ __all__ = [
     "FATAL_LEVEL",
     "LOG_FORMAT",
     "configure_logger",
+    "file_logging_enabled_from_env",
     "logger",
     "sanitize_for_log",
 ]

--- a/tests/assistant/test_assistant_main.py
+++ b/tests/assistant/test_assistant_main.py
@@ -13,3 +13,29 @@ def test_main_handles_keyboard_interrupt_without_reraising(monkeypatch):
     monkeypatch.setattr(assistant.asyncio, "run", raise_keyboard_interrupt)
 
     assistant.main()
+
+
+def test_main_respects_disabled_file_logging(monkeypatch):
+    add_calls = []
+
+    def fake_add(*args, **kwargs):
+        add_calls.append((args, kwargs))
+        return len(add_calls)
+
+    def fake_remove():
+        return None
+
+    def raise_keyboard_interrupt(coro):
+        coro.close()
+        raise KeyboardInterrupt()
+
+    monkeypatch.setenv("OPENLIST_ANI_FILE_LOGGING", "0")
+    monkeypatch.setattr(assistant.sys, "argv", ["openlist-ani-assistant", "--cli"])
+    monkeypatch.setattr(assistant.logger, "add", fake_add)
+    monkeypatch.setattr(assistant.logger, "remove", fake_remove)
+    monkeypatch.setattr(assistant.logger, "info", lambda *args, **kwargs: None)
+    monkeypatch.setattr(assistant.asyncio, "run", raise_keyboard_interrupt)
+
+    assistant.main()
+
+    assert add_calls == []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 """Shared test helpers and fixtures."""
 
+import os
 import sys
 from types import SimpleNamespace
 from pathlib import Path
+
+os.environ.setdefault("OPENLIST_ANI_FILE_LOGGING", "0")
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -40,7 +40,7 @@ def test_configure_logger_uses_clickable_source_location(monkeypatch, tmp_path):
     monkeypatch.setattr(logger_module, "LOG_DIR", tmp_path)
     monkeypatch.setattr(logger_module, "stdout", sink)
 
-    logger_module.configure_logger(level="INFO", log_name="test")
+    logger_module.configure_logger(level="INFO", log_name="test", file_logging=True)
     try:
         logger_module.logger.info("compact format")
     finally:
@@ -59,7 +59,7 @@ def test_logger_sanitizes_messages(monkeypatch, tmp_path):
     monkeypatch.setattr(logger_module, "LOG_DIR", tmp_path)
     monkeypatch.setattr(logger_module, "stdout", sink)
 
-    logger_module.configure_logger(level="INFO", log_name="test")
+    logger_module.configure_logger(level="INFO", log_name="test", file_logging=True)
     try:
         logger_module.logger.info(
             "fetch failed: https://example.com/rss?token=plain-secret"
@@ -118,7 +118,7 @@ def test_console_logger_uses_colorized_format(monkeypatch, tmp_path):
     monkeypatch.setattr(logger_module.logger, "add", fake_add)
     monkeypatch.setattr(logger_module.logger, "remove", lambda: None)
 
-    logger_module.configure_logger(level="INFO", log_name="test")
+    logger_module.configure_logger(level="INFO", log_name="test", file_logging=True)
 
     console_call = calls[0]
     file_call = calls[1]
@@ -136,3 +136,21 @@ def test_console_logger_uses_colorized_format(monkeypatch, tmp_path):
         "format"
     ].index("{message}")
     assert "colorize" not in file_call
+
+
+def test_configure_logger_respects_file_logging_env(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_add(*args, **kwargs):
+        calls.append((args, kwargs))
+        return len(calls)
+
+    monkeypatch.setenv("OPENLIST_ANI_FILE_LOGGING", "0")
+    monkeypatch.setattr(logger_module, "LOG_DIR", tmp_path)
+    monkeypatch.setattr(logger_module.logger, "add", fake_add)
+    monkeypatch.setattr(logger_module.logger, "remove", lambda: None)
+
+    logger_module.configure_logger(level="INFO", log_name="test")
+
+    assert len(calls) == 1
+    assert calls[0][0][0] is logger_module.stdout


### PR DESCRIPTION
## Summary
- Add a shared `OPENLIST_ANI_FILE_LOGGING` switch for loguru file sinks.
- Disable file logging by default in pytest via `tests/conftest.py`.
- Make the assistant entrypoint respect the same switch so pytest does not create `logs/assistant_*.log`.

## Test Plan
- `uv run ruff check src/openlist_ani/logger.py src/openlist_ani/assistant/__init__.py tests/conftest.py tests/test_logger.py tests/assistant/test_assistant_main.py`
- `uv run pytest`
- Verified `logs/` remains empty after the full pytest run.
