### PR TITLE
Improve ingestion reliability and assistant messaging

### DIFF
--- a/src/openlist_ani/adapters/outbound/downloaders/openlist/downloader.py
+++ b/src/openlist_ani/adapters/outbound/downloaders/openlist/downloader.py
@@ -21,6 +21,7 @@ from openlist_ani.integrations.openlist import (
 )
 
 from .file_detection import OpenListFileDetector
+from .task_snapshot_cache import OpenListTaskSnapshotCache
 from .workflow import OpenListDownloadWorkflow
 
 
@@ -43,6 +44,7 @@ class OpenListDownloader:
         )
         self._client = client
         self._sleep = sleep
+        self._task_snapshot_cache = OpenListTaskSnapshotCache(client)
 
     @property
     def downloader_type(self) -> str:
@@ -77,6 +79,7 @@ class OpenListDownloader:
             file_detector=OpenListFileDetector(self._client, self._sleep),
             conflict_resolver=OpenListFileConflictResolver(self._client, self._sleep),
             sleep=self._sleep,
+            task_snapshot_cache=self._task_snapshot_cache,
         )
 
     def _task_from_request(

--- a/src/openlist_ani/adapters/outbound/downloaders/openlist/task_snapshot_cache.py
+++ b/src/openlist_ani/adapters/outbound/downloaders/openlist/task_snapshot_cache.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+
+from openlist_ani.integrations.openlist import OpenListClient, OpenlistTask
+
+TaskListFetcher = Callable[[], Awaitable[list[OpenlistTask] | None]]
+
+
+class OpenListTaskSnapshotCache:
+    """Very short-lived OpenList task-list snapshots shared by workflows."""
+
+    def __init__(
+        self,
+        client: OpenListClient,
+        ttl_seconds: float = 0.5,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._client = client
+        self._ttl_seconds = max(0.0, ttl_seconds)
+        self._monotonic = monotonic
+        self._items: dict[str, tuple[float, list[OpenlistTask]]] = {}
+        self._generation = 0
+
+    async def get_offline_download_undone(self) -> list[OpenlistTask] | None:
+        return await self._get(
+            "offline_download_undone",
+            self._client.get_offline_download_undone,
+        )
+
+    async def get_offline_download_done(self) -> list[OpenlistTask] | None:
+        return await self._get(
+            "offline_download_done",
+            self._client.get_offline_download_done,
+        )
+
+    async def get_offline_download_transfer_undone(
+        self,
+    ) -> list[OpenlistTask] | None:
+        return await self._get(
+            "offline_download_transfer_undone",
+            self._client.get_offline_download_transfer_undone,
+        )
+
+    async def get_offline_download_transfer_done(self) -> list[OpenlistTask] | None:
+        return await self._get(
+            "offline_download_transfer_done",
+            self._client.get_offline_download_transfer_done,
+        )
+
+    def invalidate(self) -> None:
+        self._items.clear()
+        self._generation += 1
+
+    async def _get(
+        self,
+        key: str,
+        fetcher: TaskListFetcher,
+    ) -> list[OpenlistTask] | None:
+        now = self._monotonic()
+        cached = self._items.get(key)
+        if cached is not None:
+            expires_at, value = cached
+            if now < expires_at:
+                return value
+
+        generation = self._generation
+        value = await fetcher()
+        if value is not None and generation == self._generation:
+            self._items[key] = (now + self._ttl_seconds, value)
+        return value

--- a/src/openlist_ani/adapters/outbound/downloaders/openlist/workflow.py
+++ b/src/openlist_ani/adapters/outbound/downloaders/openlist/workflow.py
@@ -19,6 +19,7 @@ from openlist_ani.integrations.openlist import (
 from openlist_ani.logger import logger
 
 from .file_detection import OpenListFileDetector
+from .task_snapshot_cache import OpenListTaskSnapshotCache
 
 OPENLIST_TEMP_ROOT_DIRECTORY_NAME = ".oani-download-tmp"
 OPENLIST_WORKFLOW_STATE_KEY = "workflow_state"
@@ -105,12 +106,16 @@ class OpenListDownloadWorkflow:
         file_detector: OpenListFileDetector,
         conflict_resolver: OpenListFileConflictResolver,
         sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        task_snapshot_cache: OpenListTaskSnapshotCache | None = None,
     ) -> None:
         self._client = client
         self._offline_download_tool = offline_download_tool
         self._file_detector = file_detector
         self._conflict_resolver = conflict_resolver
         self._sleep = sleep
+        self._task_snapshot_cache = task_snapshot_cache or OpenListTaskSnapshotCache(
+            client
+        )
 
     async def run(
         self,
@@ -216,6 +221,7 @@ class OpenListDownloadWorkflow:
         if not tasks:
             raise DownloadError("Failed to create offline download task")
 
+        self._task_snapshot_cache.invalidate()
         task.downloader_data["task_id"] = tasks[0].id
         logger.debug(f"OpenList task created: {tasks[0].id}")
 
@@ -246,7 +252,7 @@ class OpenListDownloadWorkflow:
             raise DownloadError(f"Task {task_id} not found in undone or done lists")
 
     async def _find_undone_download_task(self, task_id: str) -> OpenlistTask | None:
-        undone = await self._client.get_offline_download_undone()
+        undone = await self._task_snapshot_cache.get_offline_download_undone()
         if undone is None:
             raise DownloadError("Failed to fetch undone download tasks")
         return next((t for t in undone if t.id == task_id), None)
@@ -269,7 +275,7 @@ class OpenListDownloadWorkflow:
         return False
 
     async def _download_task_is_done(self, task_id: str) -> bool:
-        done = await self._client.get_offline_download_done()
+        done = await self._task_snapshot_cache.get_offline_download_done()
         if done is None:
             raise DownloadError("Failed to fetch done download tasks")
 
@@ -282,13 +288,13 @@ class OpenListDownloadWorkflow:
 
     async def _transfer_task_exists(self, task: DownloadTask) -> bool:
         task_uuid = task.id
-        undone = await self._client.get_offline_download_transfer_undone()
+        undone = await self._task_snapshot_cache.get_offline_download_transfer_undone()
         if undone is None:
             logger.debug("Could not probe undone transfer tasks")
         elif any(task_uuid in transfer.name for transfer in undone):
             return True
 
-        done = await self._client.get_offline_download_transfer_done()
+        done = await self._task_snapshot_cache.get_offline_download_transfer_done()
         if done is None:
             logger.debug("Could not probe done transfer tasks")
             return False
@@ -303,7 +309,9 @@ class OpenListDownloadWorkflow:
         not_found_count = 0
 
         while True:
-            undone = await self._client.get_offline_download_transfer_undone()
+            undone = (
+                await self._task_snapshot_cache.get_offline_download_transfer_undone()
+            )
             if undone is None:
                 raise DownloadError("Failed to fetch undone transfer tasks")
 
@@ -319,7 +327,7 @@ class OpenListDownloadWorkflow:
                 await self._sleep(self._TRANSFER_CHECK_INTERVAL_SECONDS)
                 continue
 
-            done = await self._client.get_offline_download_transfer_done()
+            done = await self._task_snapshot_cache.get_offline_download_transfer_done()
             if done is None:
                 raise DownloadError("Failed to fetch done transfer tasks")
 

--- a/src/openlist_ani/adapters/outbound/feed_sources/feed_source.py
+++ b/src/openlist_ani/adapters/outbound/feed_sources/feed_source.py
@@ -13,6 +13,8 @@ class FeedSource(ABC):
     Abstract base class for RSS feed sources.
     """
 
+    entry_concurrency: int | None = None
+
     async def fetch_feed(self, url: str) -> list[AnimeRelease]:
         """Fetch and parse RSS feed from a URL.
 
@@ -34,18 +36,7 @@ class FeedSource(ABC):
 
                     feed = feedparser.parse(content)
 
-                    tasks = [self.parse_entry(entry, session) for entry in feed.entries]
-                    results = await asyncio.gather(*tasks, return_exceptions=True)
-
-                    entries: list[AnimeRelease] = []
-                    for res in results:
-                        if isinstance(res, Exception):
-                            logger.warning(f"Failed to parse RSS entry: {res}")
-                            continue
-                        if res:
-                            entries.append(res)
-
-                    return entries
+                    return await self._parse_entries(feed.entries, session)
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
             logger.warning(f"RSS fetch failed for {url}: {e}")
             return []
@@ -67,3 +58,34 @@ class FeedSource(ABC):
             Parsed AnimeRelease or None if parsing fails
         """
         pass
+
+    async def _parse_entries(
+        self,
+        entries,
+        session: aiohttp.ClientSession,
+    ) -> list[AnimeRelease]:
+        concurrency = self.entry_concurrency
+        semaphore = (
+            asyncio.Semaphore(concurrency)
+            if concurrency is not None and concurrency > 0
+            else None
+        )
+
+        async def parse_one(entry):
+            if semaphore is None:
+                return await self.parse_entry(entry, session)
+            async with semaphore:
+                return await self.parse_entry(entry, session)
+
+        tasks = [parse_one(entry) for entry in entries]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        parsed: list[AnimeRelease] = []
+        for res in results:
+            if isinstance(res, Exception):
+                logger.warning(f"Failed to parse RSS entry: {res}")
+                continue
+            if res:
+                parsed.append(res)
+
+        return parsed

--- a/src/openlist_ani/adapters/outbound/feed_sources/mikan.py
+++ b/src/openlist_ani/adapters/outbound/feed_sources/mikan.py
@@ -10,6 +10,8 @@ from openlist_ani.domain.anime_release import AnimeRelease
 
 
 class MikanFeedSource(FeedSource):
+    entry_concurrency = 5
+
     _CN_NUM_MAP = {
         "一": 1,
         "二": 2,

--- a/src/openlist_ani/adapters/outbound/persistence/__init__.py
+++ b/src/openlist_ani/adapters/outbound/persistence/__init__.py
@@ -2,8 +2,10 @@
 
 from .json_task_memento_store import JsonTaskMementoStore
 from .sqlite_anime_library_repository import SqliteAnimeLibraryRepository
+from .sqlite_task_memento_store import SqliteTaskMementoStore
 
 __all__ = [
     "JsonTaskMementoStore",
     "SqliteAnimeLibraryRepository",
+    "SqliteTaskMementoStore",
 ]

--- a/src/openlist_ani/adapters/outbound/persistence/sqlite_anime_library_repository.py
+++ b/src/openlist_ani/adapters/outbound/persistence/sqlite_anime_library_repository.py
@@ -1,11 +1,15 @@
 from datetime import datetime
 from pathlib import Path
+from typing import TypeVar
 
 import aiosqlite
 
 from openlist_ani.domain.anime_release import AnimeRelease
 
 DEFAULT_DB_PATH = Path.cwd() / "data/data.db"
+SQLITE_PARAMETER_CHUNK_SIZE = 900
+SQLITE_EPISODE_KEY_CHUNK_SIZE = SQLITE_PARAMETER_CHUNK_SIZE // 3
+T = TypeVar("T")
 
 
 class SqliteAnimeLibraryRepository:
@@ -48,32 +52,64 @@ class SqliteAnimeLibraryRepository:
             row = await cursor.fetchone()
             return row is not None
 
-    async def find_releases_by_episode(
+    async def find_existing_titles(self, candidate_titles: list[str]) -> set[str]:
+        """Return candidate titles that already exist in the library."""
+        unique_titles = _deduplicate(candidate_titles)
+        if not unique_titles:
+            return set()
+
+        downloaded_titles: set[str] = set()
+        async with aiosqlite.connect(self.db_path) as db:
+            for chunk in _chunks(unique_titles, SQLITE_PARAMETER_CHUNK_SIZE):
+                placeholders = ",".join("?" for _ in chunk)
+                cursor = await db.execute(
+                    f"SELECT title FROM resources WHERE title IN ({placeholders})",
+                    tuple(chunk),
+                )
+                rows = await cursor.fetchall()
+                downloaded_titles.update(row[0] for row in rows)
+        return downloaded_titles
+
+    async def find_releases_by_episodes(
         self,
-        anime_name: str,
-        season: int,
-        episode: int,
-    ) -> list[dict]:
-        """Find all ingested releases for a specific episode.
+        keys: list[tuple[str, int, int]],
+    ) -> dict[tuple[str, int, int], list[dict]]:
+        """Find ingested releases for multiple episode keys."""
+        keys = _deduplicate(keys)
+        records_by_key: dict[tuple[str, int, int], list[dict]] = {
+            key: [] for key in keys
+        }
+        if not keys:
+            return records_by_key
 
-        Args:
-            anime_name: Anime series name.
-            season: Season number.
-            episode: Episode number.
-
-        Returns:
-            List of dicts with keys: fansub, quality, languages, version.
-        """
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
-            cursor = await db.execute(
-                "SELECT fansub, quality, languages, version "
-                "FROM resources "
-                "WHERE anime_name = ? AND season = ? AND episode = ?",
-                (anime_name, season, episode),
+            rows = []
+            for chunk in _chunks(keys, SQLITE_EPISODE_KEY_CHUNK_SIZE):
+                clauses = " OR ".join(
+                    "(anime_name = ? AND season = ? AND episode = ?)" for _ in chunk
+                )
+                params = tuple(value for key in chunk for value in key)
+                cursor = await db.execute(
+                    "SELECT anime_name, season, episode, fansub, quality, "
+                    "languages, version "
+                    "FROM resources "
+                    f"WHERE {clauses}",
+                    params,
+                )
+                rows.extend(await cursor.fetchall())
+
+        for row in rows:
+            key = (row["anime_name"], row["season"], row["episode"])
+            records_by_key.setdefault(key, []).append(
+                {
+                    "fansub": row["fansub"],
+                    "quality": row["quality"],
+                    "languages": row["languages"],
+                    "version": row["version"],
+                }
             )
-            rows = await cursor.fetchall()
-            return [dict(row) for row in rows]
+        return records_by_key
 
     async def remove_release(self, title: str) -> None:
         """Remove a library entry by title."""
@@ -128,3 +164,12 @@ class SqliteAnimeLibraryRepository:
                 await db.commit()
             except aiosqlite.IntegrityError:
                 pass
+
+
+def _deduplicate(items: list[T]) -> list[T]:
+    return list(dict.fromkeys(items))
+
+
+def _chunks(items: list[T], size: int):
+    for index in range(0, len(items), size):
+        yield items[index : index + size]

--- a/src/openlist_ani/adapters/outbound/persistence/sqlite_task_memento_store.py
+++ b/src/openlist_ani/adapters/outbound/persistence/sqlite_task_memento_store.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from openlist_ani.domain.download_task.memento import TaskMemento
+from openlist_ani.domain.download_task.task import TERMINAL_STATES
+from openlist_ani.logger import logger
+
+DEFAULT_TASK_MEMENTO_DB_PATH = Path.cwd() / "data/task_mementos.db"
+LEGACY_JSON_IMPORT_KEY = "legacy_json_imported"
+
+
+class SqliteTaskMementoStore:
+    """SQLite-backed memento store with one durable row per active task."""
+
+    def __init__(
+        self,
+        path: str | Path = DEFAULT_TASK_MEMENTO_DB_PATH,
+        legacy_json_path: str | Path | None = None,
+    ) -> None:
+        self.path = Path(path)
+        self.legacy_json_path = Path(legacy_json_path) if legacy_json_path else None
+        self._initialized = False
+
+    def load_all(self) -> list[TaskMemento]:
+        self._ensure_initialized()
+        with self._connect() as db:
+            rows = db.execute(
+                "SELECT payload FROM task_mementos ORDER BY updated_at, task_id"
+            ).fetchall()
+
+        tasks: list[TaskMemento] = []
+        for (payload,) in rows:
+            try:
+                tasks.append(TaskMemento.from_dict(json.loads(payload)))
+            except Exception as e:
+                logger.error(
+                    f"Failed to load task memento from {self.path}: {e}. "
+                    "The corrupted task will not be restored."
+                )
+        return tasks
+
+    def save(self, task_memento: TaskMemento) -> None:
+        self._ensure_initialized()
+        if task_memento.state in TERMINAL_STATES:
+            self.delete(task_memento.task_id)
+            return
+
+        task_memento.touch()
+        payload = json.dumps(task_memento.to_dict(), ensure_ascii=False)
+        with self._connect() as db:
+            db.execute(
+                """
+                INSERT INTO task_mementos (task_id, state, updated_at, payload)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(task_id) DO UPDATE SET
+                    state = excluded.state,
+                    updated_at = excluded.updated_at,
+                    payload = excluded.payload
+                """,
+                (
+                    task_memento.task_id,
+                    task_memento.state.value,
+                    task_memento.updated_at,
+                    payload,
+                ),
+            )
+
+    def delete(self, task_id: str) -> None:
+        self._ensure_initialized()
+        with self._connect() as db:
+            db.execute("DELETE FROM task_mementos WHERE task_id = ?", (task_id,))
+
+    def atomic_flush(self) -> None:
+        self._ensure_initialized()
+
+    def _ensure_initialized(self) -> None:
+        if self._initialized:
+            return
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as db:
+            db.execute("""
+                CREATE TABLE IF NOT EXISTS task_mementos (
+                    task_id TEXT PRIMARY KEY,
+                    state TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    payload TEXT NOT NULL
+                )
+                """)
+            db.execute(
+                "CREATE INDEX IF NOT EXISTS idx_task_mementos_updated_at "
+                "ON task_mementos(updated_at)"
+            )
+            db.execute("""
+                CREATE TABLE IF NOT EXISTS task_memento_metadata (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                )
+                """)
+            self._import_legacy_json_if_empty(db)
+        self._initialized = True
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.path, timeout=30)
+
+    def _import_legacy_json_if_empty(self, db: sqlite3.Connection) -> None:
+        if self.legacy_json_path is None or not self.legacy_json_path.exists():
+            return
+        if self._legacy_import_done(db):
+            return
+
+        row_count = db.execute("SELECT COUNT(*) FROM task_mementos").fetchone()[0]
+        if row_count:
+            self._mark_legacy_import_done(db)
+            return
+
+        imported = 0
+        legacy_tasks, loaded = self._load_legacy_tasks()
+        if not loaded:
+            return
+
+        for task in legacy_tasks:
+            if task.state in TERMINAL_STATES:
+                continue
+            db.execute(
+                """
+                INSERT OR REPLACE INTO task_mementos
+                    (task_id, state, updated_at, payload)
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    task.task_id,
+                    task.state.value,
+                    task.updated_at,
+                    json.dumps(task.to_dict(), ensure_ascii=False),
+                ),
+            )
+            imported += 1
+
+        if imported:
+            logger.info(
+                f"Imported {imported} legacy task mementos from "
+                f"{self.legacy_json_path} into {self.path}"
+            )
+        self._mark_legacy_import_done(db)
+
+    def _legacy_import_done(self, db: sqlite3.Connection) -> bool:
+        row = db.execute(
+            "SELECT value FROM task_memento_metadata WHERE key = ?",
+            (LEGACY_JSON_IMPORT_KEY,),
+        ).fetchone()
+        return row is not None
+
+    def _mark_legacy_import_done(self, db: sqlite3.Connection) -> None:
+        db.execute(
+            """
+            INSERT INTO task_memento_metadata (key, value)
+            VALUES (?, ?)
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            """,
+            (LEGACY_JSON_IMPORT_KEY, str(self.legacy_json_path)),
+        )
+
+    def _load_legacy_tasks(self) -> tuple[list[TaskMemento], bool]:
+        if self.legacy_json_path is None:
+            return [], True
+
+        try:
+            raw = json.loads(self.legacy_json_path.read_text(encoding="utf-8"))
+            items = raw.get("tasks", [])
+        except Exception as e:
+            logger.error(
+                f"Failed to read legacy task mementos from "
+                f"{self.legacy_json_path}: {e}"
+            )
+            return [], False
+
+        tasks: list[TaskMemento] = []
+        for item in items:
+            try:
+                tasks.append(TaskMemento.from_dict(item))
+            except Exception as e:
+                logger.error(
+                    f"Failed to import legacy task memento from "
+                    f"{self.legacy_json_path}: {e}"
+                )
+        return tasks, True

--- a/src/openlist_ani/application/anime_library_ingestion/filters/priority.py
+++ b/src/openlist_ani/application/anime_library_ingestion/filters/priority.py
@@ -70,12 +70,17 @@ class PriorityFilter:
 
         # Group by (anime_name, season, episode).
         groups = group_by_episode(candidates)
+        episode_keys = [key for key in groups if key is not None]
+        records_by_key = await self._records_by_episode(episode_keys)
+        active_records_by_key = self._active_records_by_episode()
         accepted: list[AnimeRelease] = []
 
         for key, group in groups.items():
-            filtered = await self._filter_group(
+            filtered = self._filter_group(
                 key,
                 group,
+                records_by_key.get(key, []),
+                active_records_by_key.get(key, []),
                 fansub_list,
                 language_list,
                 quality_list,
@@ -92,10 +97,12 @@ class PriorityFilter:
 
     # ── per-group filtering ──────────────────────────────────────────
 
-    async def _filter_group(
+    def _filter_group(
         self,
         key: EpisodeKey | None,
         group: list[AnimeRelease],
+        episode_records: list[dict],
+        active_records: list[dict],
         fansub_list: list[str],
         language_list: list[str],
         quality_list: list[str],
@@ -106,14 +113,7 @@ class PriorityFilter:
         if key is None:
             return group
 
-        anime_name, season, episode = key
-        known = await self._anime_library_repository.find_releases_by_episode(
-            anime_name, season, episode
-        )
-        known = [
-            *known,
-            *self._active_records_for_episode(anime_name, season, episode),
-        ]
+        known = [*episode_records, *active_records]
 
         accepted: list[AnimeRelease] = []
         remaining: list[AnimeRelease] = []
@@ -154,25 +154,30 @@ class PriorityFilter:
 
         return accepted
 
-    def _active_records_for_episode(
+    async def _records_by_episode(
         self,
-        anime_name: str,
-        season: int,
-        episode: int,
-    ) -> list[dict]:
-        if self._active_task_query is None:
-            return []
+        keys: list[EpisodeKey],
+    ) -> dict[EpisodeKey, list[dict]]:
+        if not keys:
+            return {}
 
-        records: list[dict] = []
+        return dict(
+            await self._anime_library_repository.find_releases_by_episodes(keys)
+        )
+
+    def _active_records_by_episode(self) -> dict[EpisodeKey, list[dict]]:
+        if self._active_task_query is None:
+            return {}
+
+        records: dict[EpisodeKey, list[dict]] = {}
         for task in self._active_task_query.list_active_tasks():
             release = task.release
-            if (
-                release.anime_name != anime_name
-                or release.season != season
-                or release.episode != episode
-            ):
+            if release.anime_name is None or release.season is None:
                 continue
-            records.append(
+            if release.episode is None:
+                continue
+            key = (release.anime_name, release.season, release.episode)
+            records.setdefault(key, []).append(
                 {
                     "fansub": release.fansub,
                     "quality": release.quality.value if release.quality else "",

--- a/src/openlist_ani/application/anime_library_ingestion/filters/strict.py
+++ b/src/openlist_ani/application/anime_library_ingestion/filters/strict.py
@@ -128,6 +128,9 @@ class StrictRenameFilter:
             return []
 
         groups = group_by_episode(candidates)
+        episode_keys = [key for key in groups if key is not None]
+        records_by_key = await self._records_by_episode(episode_keys)
+        active_stems_by_key = self._active_stems_by_episode()
         accepted: list[AnimeRelease] = []
 
         for key, group in groups.items():
@@ -135,7 +138,13 @@ class StrictRenameFilter:
                 # Not enough metadata to compute a stem — bypass.
                 accepted.extend(group)
                 continue
-            filtered = await self._filter_group(self._rename_format, key, group)
+            filtered = self._filter_group(
+                self._rename_format,
+                key,
+                group,
+                records_by_key.get(key, []),
+                active_stems_by_key.get(key, []),
+            )
             accepted.extend(filtered)
 
         skipped = len(candidates) - len(accepted)
@@ -145,18 +154,17 @@ class StrictRenameFilter:
 
     # ── per-group filtering ──────────────────────────────────────────
 
-    async def _filter_group(
+    def _filter_group(
         self,
         rename_format: str,
         key: EpisodeKey,
         group: list[AnimeRelease],
+        db_records: list[dict],
+        active_stems: list[tuple[str, str, int]],
     ) -> list[AnimeRelease]:
         """Filter a single episode group against DB stems + intra-batch dedup."""
         anime_name, season, episode = key
 
-        db_records = await self._anime_library_repository.find_releases_by_episode(
-            anime_name, season, episode
-        )
         db_stems: list[tuple[str, int]] = [
             (
                 _stem_from_db_record(rename_format, anime_name, season, episode, rec),
@@ -164,7 +172,6 @@ class StrictRenameFilter:
             )
             for rec in db_records
         ]
-        active_stems = self._active_stems_for_episode(key)
 
         # Phase 1: filter against DB records and active downloads.
         after_db: list[AnimeRelease] = []
@@ -188,24 +195,32 @@ class StrictRenameFilter:
         # Phase 2: intra-batch dedup — same stem keeps highest version only.
         return self._dedup_batch(rename_format, after_db)
 
-    def _active_stems_for_episode(
+    async def _records_by_episode(
         self,
-        key: EpisodeKey,
-    ) -> list[tuple[str, str, int]]:
-        if self._active_task_query is None:
-            return []
+        keys: list[EpisodeKey],
+    ) -> dict[EpisodeKey, list[dict]]:
+        if not keys:
+            return {}
 
-        anime_name, season, episode = key
-        stems: list[tuple[str, str, int]] = []
+        return dict(
+            await self._anime_library_repository.find_releases_by_episodes(keys)
+        )
+
+    def _active_stems_by_episode(
+        self,
+    ) -> dict[EpisodeKey, list[tuple[str, str, int]]]:
+        if self._active_task_query is None:
+            return {}
+
+        stems: dict[EpisodeKey, list[tuple[str, str, int]]] = {}
         for task in self._active_task_query.list_active_tasks():
             release = task.release
-            if (
-                release.anime_name != anime_name
-                or release.season != season
-                or release.episode != episode
-            ):
+            if release.anime_name is None or release.season is None:
                 continue
-            stems.append(
+            if release.episode is None:
+                continue
+            key = (release.anime_name, release.season, release.episode)
+            stems.setdefault(key, []).append(
                 (
                     self._directory_planner.target_directory_path(
                         task.base_path,

--- a/src/openlist_ani/application/anime_library_ingestion/ports.py
+++ b/src/openlist_ani/application/anime_library_ingestion/ports.py
@@ -78,11 +78,13 @@ class DownloadTaskReservationPort(Protocol):
 class AnimeLibraryRepositoryPort(Protocol):
     async def is_downloaded(self, title: str) -> bool: ...
 
+    async def find_existing_titles(self, candidate_titles: list[str]) -> set[str]: ...
+
     async def add_release(self, release: AnimeRelease) -> None: ...
 
-    async def find_releases_by_episode(
-        self, anime_name: str, season: int, episode: int
-    ) -> list[dict]: ...
+    async def find_releases_by_episodes(
+        self, keys: list[tuple[str, int, int]]
+    ) -> dict[tuple[str, int, int], list[dict]]: ...
 
 
 class NotifierPort(Protocol):

--- a/src/openlist_ani/application/anime_library_ingestion/stages.py
+++ b/src/openlist_ani/application/anime_library_ingestion/stages.py
@@ -202,11 +202,15 @@ class RSSStage(PipelineStage[None]):
     ) -> tuple[list[AnimeRelease], str]:
         accepted: list[AnimeRelease] = []
         reasons: dict[str, int] = {}
+        downloadable_titles = [entry.title for entry in entries if entry.download_url]
+        downloaded_titles = await self._anime_library_repository.find_existing_titles(
+            downloadable_titles
+        )
         for entry in entries:
             reason: str | None = None
             if not entry.download_url:
                 reason = "missing_url"
-            elif await self._anime_library_repository.is_downloaded(entry.title):
+            elif entry.title in downloaded_titles:
                 reason = "already_downloaded"
 
             if reason is None:

--- a/src/openlist_ani/assistant/__init__.py
+++ b/src/openlist_ani/assistant/__init__.py
@@ -345,12 +345,7 @@ async def run() -> None:
         registry = ToolRegistry()
         registry.register(SkillTool(catalog))
 
-        intermediate_messages: list[str] = []
-
-        def send_message_callback(message: str) -> None:
-            intermediate_messages.append(message)
-
-        registry.register(SendMessageTool(send_message_callback))
+        registry.register(SendMessageTool())
         registry.register(AgentTool(provider, registry))
         registry.register(WebFetchTool(provider, registry))
         registry.register(MemoryTool(memory.memory_dir))
@@ -383,6 +378,7 @@ async def run() -> None:
     # Select frontend
     is_cli = "--cli" in sys.argv
     is_resume = "--resume" in sys.argv
+    frontends: list[Any] = []
 
     if is_cli:
         frontend = await _create_cli_frontend(
@@ -415,6 +411,10 @@ async def run() -> None:
             await asyncio.gather(*(frontend.run() for frontend in frontends))
     finally:
         logger.info("Shutting down assistant - cleaning up resources")
+        for running_frontend in frontends:
+            shutdown = getattr(running_frontend, "shutdown", None)
+            if shutdown is not None:
+                await shutdown()
         await loop.shutdown()
         await provider.close()
 

--- a/src/openlist_ani/assistant/core/loop.py
+++ b/src/openlist_ani/assistant/core/loop.py
@@ -856,6 +856,7 @@ class AgenticLoop:
                     tool_result_preview=preview,
                 )
             )
+            await self._emit_intermediate_message(response, result, queue)
 
             # Yield to event loop so that any pending background tasks
             # (e.g. frontend enqueuing a user message) get a chance to run.
@@ -875,6 +876,28 @@ class AgenticLoop:
                 return completed_results, executed_tool_ids, True
 
         return completed_results, executed_tool_ids, False
+
+    @staticmethod
+    async def _emit_intermediate_message(
+        response: ProviderResponse,
+        result: ToolResult,
+        queue: asyncio.Queue[LoopEvent | None],
+    ) -> None:
+        if result.name != "send_message" or result.is_error:
+            return
+
+        matching_call = next(
+            (tc for tc in response.tool_calls if tc.id == result.tool_call_id),
+            None,
+        )
+        if matching_call is None:
+            return
+
+        message = matching_call.arguments.get("message")
+        if isinstance(message, str) and message:
+            await queue.put(
+                LoopEvent(type=EventType.INTERMEDIATE_MESSAGE, text=message)
+            )
 
     def _inject_interrupted_tombstones(
         self,

--- a/src/openlist_ani/assistant/core/models.py
+++ b/src/openlist_ani/assistant/core/models.py
@@ -119,6 +119,7 @@ class EventType(str, Enum):
     THINKING = "thinking"
     TEXT_DELTA = "text_delta"
     TEXT_DONE = "text_done"
+    INTERMEDIATE_MESSAGE = "intermediate_message"
     TOOL_START = "tool_start"
     TOOL_END = "tool_end"
     ERROR = "error"

--- a/src/openlist_ani/assistant/frontend/messaging.py
+++ b/src/openlist_ani/assistant/frontend/messaging.py
@@ -81,6 +81,12 @@ class MessagingFrontend(Frontend):
     async def run(self) -> None:
         await self._messenger.listen(self.handle_inbound)
 
+    async def shutdown(self) -> None:
+        loops = list(dict.fromkeys(self._chat_loops.values()))
+        for loop in loops:
+            await loop.shutdown()
+        self._chat_loops.clear()
+
     async def send_response(self, text: str) -> None:
         raise NotImplementedError("MessagingFrontend sends through inbound targets")
 
@@ -109,6 +115,8 @@ class MessagingFrontend(Frontend):
                     final_parts.append(event.text)
                 elif event.type == EventType.ERROR and event.text:
                     final_parts.append(f"Error: {event.text}")
+                elif event.type == EventType.INTERMEDIATE_MESSAGE and event.text:
+                    await self._messenger.send_text(message.target.chat_id, event.text)
             response = "\n".join(final_parts).strip() or "No response."
             await self._messenger.send_text(message.target.chat_id, response)
         except Exception as exc:  # noqa: BLE001

--- a/src/openlist_ani/assistant/frontend/telegram.py
+++ b/src/openlist_ani/assistant/frontend/telegram.py
@@ -438,6 +438,7 @@ class TelegramFrontend(Frontend):
             EventType.TOOL_START: self._on_tool_start,
             EventType.TOOL_END: self._on_tool_end,
             EventType.TEXT_DELTA: self._on_text_delta,
+            EventType.INTERMEDIATE_MESSAGE: self._on_intermediate_message,
             EventType.ERROR: self._on_error,
             EventType.USER_MESSAGE_INJECTED: self._on_injected,
         }
@@ -452,6 +453,12 @@ class TelegramFrontend(Frontend):
         if args_str:
             tool_line += f"({args_str})"
         lines.append(tool_line)
+        await self._debounced_edit(status_msg, lines, edit_state)
+
+    async def _on_intermediate_message(
+        self, event, status_msg, lines, edit_state, _final_parts
+    ):
+        lines.append(f"💬 {event.text}")
         await self._debounced_edit(status_msg, lines, edit_state)
 
     async def _on_tool_end(self, event, status_msg, lines, edit_state, _final_parts):

--- a/src/openlist_ani/assistant/frontend/textual_app/app.py
+++ b/src/openlist_ani/assistant/frontend/textual_app/app.py
@@ -722,6 +722,7 @@ class TextualFrontend(App):
             EventType.THINKING: self._handle_thinking,
             EventType.TEXT_DELTA: self._handle_text_delta,
             EventType.TEXT_DONE: self._handle_text_done,
+            EventType.INTERMEDIATE_MESSAGE: self._handle_intermediate_message,
             EventType.TOOL_START: self._handle_tool_start,
             EventType.TOOL_END: self._handle_tool_end,
             EventType.ERROR: self._handle_error,
@@ -819,6 +820,13 @@ class TextualFrontend(App):
         args_str = self._format_tool_args(event.tool_args)
         chat = self.query_one(_CHAT_VIEW, VerticalScroll)
         block = MessageBlock.tool_start(event.tool_name, args_str)
+        await chat.mount(block)
+        self._scroll_to_bottom()
+
+    async def _handle_intermediate_message(self, event: LoopEvent) -> None:
+        await self._remove_spinner()
+        chat = self.query_one(_CHAT_VIEW, VerticalScroll)
+        block = MessageBlock.command_result(event.text, style="dim")
         await chat.mount(block)
         self._scroll_to_bottom()
 

--- a/src/openlist_ani/assistant/tool/builtin/send_message_tool.py
+++ b/src/openlist_ani/assistant/tool/builtin/send_message_tool.py
@@ -18,7 +18,7 @@ MessageCallback = Callable[[str], None]
 class SendMessageTool(BaseTool):
     """Tool that sends intermediate messages to the user."""
 
-    def __init__(self, callback: MessageCallback) -> None:
+    def __init__(self, callback: MessageCallback | None = None) -> None:
         self._callback = callback
 
     @property
@@ -53,5 +53,6 @@ class SendMessageTool(BaseTool):
         if not message:
             return "Error: message is required."
 
-        self._callback(message)
+        if self._callback is not None:
+            self._callback(message)
         return "Message sent."

--- a/src/openlist_ani/bootstrap/backend.py
+++ b/src/openlist_ani/bootstrap/backend.py
@@ -49,8 +49,8 @@ from openlist_ani.adapters.outbound.notifications import (
     NotificationSettings,
 )
 from openlist_ani.adapters.outbound.persistence import (
-    JsonTaskMementoStore,
     SqliteAnimeLibraryRepository,
+    SqliteTaskMementoStore,
 )
 from openlist_ani.adapters.outbound.torrent_metadata import (
     resolve_magnet,
@@ -103,7 +103,10 @@ async def run() -> None:
     await event_manager.start()
 
     notification_manager = await _setup_notifications()
-    task_memento_store = JsonTaskMementoStore("data/task_mementos.json")
+    task_memento_store = SqliteTaskMementoStore(
+        "data/task_mementos.db",
+        legacy_json_path="data/task_mementos.json",
+    )
     settings = _create_pipeline_settings()
     metadata_parser = _create_metadata_parser()
     metadata_validator = _create_metadata_validator()

--- a/src/openlist_ani/builtin_skills/skills/oani/script/parse_rss.py
+++ b/src/openlist_ani/builtin_skills/skills/oani/script/parse_rss.py
@@ -51,11 +51,9 @@ async def run(
         fansub = e.get("fansub") or "-"
         quality = e.get("quality") or "-"
         langs = ",".join(e.get("languages") or []) or "-"
-        url_short = (e.get("download_url") or "")[:60]
-        if len(e.get("download_url") or "") > 60:
-            url_short += "…"
+        download_url = e.get("download_url") or ""
         lines.append(
-            f"| {idx} | {title} | {fansub} | {quality} | {langs} | {url_short} |"
+            f"| {idx} | {title} | {fansub} | {quality} | {langs} | {download_url} |"
         )
 
     lines += [

--- a/tests/adapters/outbound/downloaders/test_openlist_downloader.py
+++ b/tests/adapters/outbound/downloaders/test_openlist_downloader.py
@@ -6,6 +6,9 @@ import pytest
 
 from openlist_ani.application.anime_library_ingestion.models import PipelineContext
 from openlist_ani.adapters.outbound.downloaders import OpenListDownloader
+from openlist_ani.adapters.outbound.downloaders.openlist.task_snapshot_cache import (
+    OpenListTaskSnapshotCache,
+)
 from openlist_ani.domain.anime_release import (
     AnimeRelease,
     LanguageType,
@@ -455,3 +458,108 @@ async def test_download_raises_when_offline_task_fails():
     client.remove_path.assert_awaited_once_with(
         "/anime/.oani-download-tmp", ["workflow-1"]
     )
+
+
+async def test_download_invalidates_stale_task_snapshots_after_submit():
+    downloader, client = _downloader()
+    client.get_offline_download_undone = AsyncMock(return_value=[])
+    client.get_offline_download_done = AsyncMock(return_value=[])
+    await downloader._task_snapshot_cache.get_offline_download_undone()
+    await downloader._task_snapshot_cache.get_offline_download_done()
+
+    client.add_offline_download = AsyncMock(
+        return_value=[
+            OpenlistTask(
+                id="offline-new",
+                name="offline",
+                state=OpenlistTaskState.SUCCEEDED,
+            )
+        ]
+    )
+    client.get_offline_download_undone = AsyncMock(return_value=[])
+    client.get_offline_download_done = AsyncMock(
+        return_value=[
+            OpenlistTask(
+                id="offline-new",
+                name="offline",
+                state=OpenlistTaskState.SUCCEEDED,
+            )
+        ]
+    )
+    client.get_offline_download_transfer_undone = AsyncMock(return_value=[])
+    client.get_offline_download_transfer_done = AsyncMock(
+        return_value=[
+            OpenlistTask(
+                id="transfer-1",
+                name="workflow-1",
+                state=OpenlistTaskState.SUCCEEDED,
+            )
+        ]
+    )
+    client.list_files = AsyncMock(
+        side_effect=[
+            [SimpleNamespace(name="raw episode [1080p].mkv", is_dir=False, size=100)],
+            [],
+        ]
+    )
+
+    result = await downloader.download(
+        PipelineContext(
+            workflow_id="workflow-1",
+            payload=DownloadRequest(
+                release=_resource(),
+                base_path="/anime",
+                target_directory_path="/anime/葬送的芙莉莲/Season 1",
+            ),
+        )
+    )
+
+    assert result.downloader_memento.payload["task_id"] == "offline-new"
+    client.get_offline_download_done.assert_awaited_once()
+
+
+async def test_openlist_task_snapshot_cache_reuses_values_within_short_ttl():
+    now = 10.0
+    client = AsyncMock()
+    task = OpenlistTask(id="offline-1", name="offline")
+    client.get_offline_download_undone = AsyncMock(return_value=[task])
+    cache = OpenListTaskSnapshotCache(
+        client,
+        ttl_seconds=0.25,
+        monotonic=lambda: now,
+    )
+
+    first = await cache.get_offline_download_undone()
+    second = await cache.get_offline_download_undone()
+
+    assert first == [task]
+    assert second == [task]
+    client.get_offline_download_undone.assert_awaited_once()
+
+    now = 10.3
+    await cache.get_offline_download_undone()
+
+    assert client.get_offline_download_undone.await_count == 2
+
+
+async def test_openlist_task_snapshot_cache_does_not_store_in_flight_stale_fetch():
+    release_fetch = asyncio.Event()
+    stale_task = OpenlistTask(id="stale", name="stale")
+    fresh_task = OpenlistTask(id="fresh", name="fresh")
+    client = AsyncMock()
+
+    async def fetch_stale():
+        await release_fetch.wait()
+        return [stale_task]
+
+    client.get_offline_download_undone = AsyncMock(side_effect=fetch_stale)
+    cache = OpenListTaskSnapshotCache(client, ttl_seconds=10)
+
+    in_flight = asyncio.create_task(cache.get_offline_download_undone())
+    await asyncio.sleep(0)
+    cache.invalidate()
+    client.get_offline_download_undone = AsyncMock(return_value=[fresh_task])
+    release_fetch.set()
+
+    assert await in_flight == [stale_task]
+    assert await cache.get_offline_download_undone() == [fresh_task]

--- a/tests/adapters/outbound/feed_sources/test_feed_source.py
+++ b/tests/adapters/outbound/feed_sources/test_feed_source.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import asyncio
+
+from openlist_ani.adapters.outbound.feed_sources.feed_source import FeedSource
+from openlist_ani.domain.anime_release import AnimeRelease
+
+
+class CountingFeedSource(FeedSource):
+    entry_concurrency = 2
+
+    def __init__(self) -> None:
+        self.active = 0
+        self.max_active = 0
+
+    async def parse_entry(self, entry, session) -> AnimeRelease | None:
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        await asyncio.sleep(0.01)
+        self.active -= 1
+        return AnimeRelease(title=f"Anime {entry}", download_url=f"magnet:?{entry}")
+
+
+async def test_parse_entries_respects_source_concurrency_limit():
+    source = CountingFeedSource()
+
+    entries = await source._parse_entries(list(range(6)), session=object())
+
+    assert len(entries) == 6
+    assert source.max_active <= 2

--- a/tests/adapters/outbound/persistence/test_sqlite_anime_library_repository.py
+++ b/tests/adapters/outbound/persistence/test_sqlite_anime_library_repository.py
@@ -5,6 +5,7 @@ import sqlite3
 from openlist_ani.adapters.outbound.persistence import (
     SqliteAnimeLibraryRepository,
 )
+from openlist_ani.domain.anime_release import AnimeRelease, VideoQuality
 
 
 async def test_repository_reuses_existing_resources_table(tmp_path):
@@ -45,3 +46,52 @@ async def test_repository_reuses_existing_resources_table(tmp_path):
         }
     assert "resources" in tables
     assert "anime_library_entries" not in tables
+
+
+async def test_repository_filters_downloaded_titles_from_large_candidate_set(tmp_path):
+    db_path = tmp_path / "data.db"
+    repository = SqliteAnimeLibraryRepository(db_path=db_path)
+    await repository.init()
+    await repository.add_release(
+        AnimeRelease(
+            title="Already Downloaded",
+            download_url="magnet:?xt=urn:btih:downloaded",
+        )
+    )
+
+    candidates = ["Already Downloaded", *[f"Candidate {index}" for index in range(950)]]
+
+    assert await repository.find_existing_titles(candidates) == {"Already Downloaded"}
+
+
+async def test_repository_finds_releases_by_many_episode_keys(tmp_path):
+    db_path = tmp_path / "data.db"
+    repository = SqliteAnimeLibraryRepository(db_path=db_path)
+    await repository.init()
+    await repository.add_release(
+        AnimeRelease(
+            title="[ANi] Test Anime - 01 [1080p]",
+            download_url="magnet:?xt=urn:btih:test",
+            anime_name="Test Anime",
+            season=1,
+            episode=1,
+            fansub="ANi",
+            quality=VideoQuality.Q1080P,
+        )
+    )
+
+    keys = [
+        ("Test Anime", 1, 1),
+        *[(f"Anime {index}", 1, 1) for index in range(1200)],
+    ]
+
+    records = await repository.find_releases_by_episodes(keys)
+
+    assert records[("Test Anime", 1, 1)] == [
+        {
+            "fansub": "ANi",
+            "quality": "1080p",
+            "languages": "",
+            "version": 1,
+        }
+    ]

--- a/tests/adapters/outbound/persistence/test_sqlite_task_memento_store.py
+++ b/tests/adapters/outbound/persistence/test_sqlite_task_memento_store.py
@@ -1,0 +1,113 @@
+import json
+import sqlite3
+
+from openlist_ani.adapters.outbound.persistence import (
+    JsonTaskMementoStore,
+    SqliteTaskMementoStore,
+)
+from openlist_ani.domain.anime_release import AnimeRelease, LanguageType, VideoQuality
+from openlist_ani.domain.download_task.memento import TaskMemento
+from openlist_ani.domain.download_task.task import DownloadState
+
+
+def test_sqlite_memento_store_round_trip_real_release(tmp_path):
+    db_path = tmp_path / "task_mementos.db"
+    store = SqliteTaskMementoStore(db_path)
+    task = _task("task-1", state=DownloadState.DOWNLOADED)
+    task.pipeline.next_buffer = "rename"
+    task.pipeline.downloaded_directory_path = "/anime/葬送的芙莉莲/Season 1"
+    task.pipeline.downloaded_filename = "raw file.mp4"
+
+    store.save(task)
+    loaded = SqliteTaskMementoStore(db_path).load_all()
+
+    assert len(loaded) == 1
+    assert loaded[0].release.anime_name == "葬送的芙莉莲"
+    assert loaded[0].release.quality == VideoQuality.Q1080P
+    assert loaded[0].release.languages == [LanguageType.CHT]
+    assert loaded[0].pipeline.next_buffer == "rename"
+
+
+def test_sqlite_memento_store_persists_each_task_as_own_row(tmp_path):
+    db_path = tmp_path / "task_mementos.db"
+    store = SqliteTaskMementoStore(db_path)
+
+    store.save(_task("task-1", state=DownloadState.PENDING))
+    store.save(_task("task-2", state=DownloadState.DOWNLOADING))
+    updated = _task("task-1", state=DownloadState.DOWNLOADED)
+    updated.output_path = "/anime/out.mkv"
+    store.save(updated)
+
+    with sqlite3.connect(db_path) as db:
+        rows = db.execute(
+            "SELECT task_id, state, payload FROM task_mementos ORDER BY task_id"
+        ).fetchall()
+
+    assert [row[0] for row in rows] == ["task-1", "task-2"]
+    assert [row[1] for row in rows] == ["downloaded", "downloading"]
+    payload = json.loads(rows[0][2])
+    assert payload["task_id"] == "task-1"
+    assert "tasks" not in payload
+
+
+def test_sqlite_memento_store_deletes_terminal_task_without_dropping_others(tmp_path):
+    db_path = tmp_path / "task_mementos.db"
+    store = SqliteTaskMementoStore(db_path)
+    store.save(_task("active", state=DownloadState.DOWNLOADING))
+    store.save(_task("done", state=DownloadState.DOWNLOADED))
+
+    terminal = _task("done", state=DownloadState.COMPLETED)
+    store.save(terminal)
+    loaded = SqliteTaskMementoStore(db_path).load_all()
+
+    assert [task.task_id for task in loaded] == ["active"]
+
+
+def test_sqlite_memento_store_imports_legacy_json_when_empty(tmp_path):
+    legacy_path = tmp_path / "task_mementos.json"
+    db_path = tmp_path / "task_mementos.db"
+    JsonTaskMementoStore(legacy_path).save(_task("legacy", DownloadState.DOWNLOADING))
+
+    loaded = SqliteTaskMementoStore(
+        db_path,
+        legacy_json_path=legacy_path,
+    ).load_all()
+
+    assert [task.task_id for task in loaded] == ["legacy"]
+    assert SqliteTaskMementoStore(db_path).load_all()[0].task_id == "legacy"
+
+
+def test_sqlite_memento_store_imports_legacy_json_only_once(tmp_path):
+    legacy_path = tmp_path / "task_mementos.json"
+    db_path = tmp_path / "task_mementos.db"
+    JsonTaskMementoStore(legacy_path).save(_task("legacy", DownloadState.DOWNLOADING))
+
+    store = SqliteTaskMementoStore(db_path, legacy_json_path=legacy_path)
+    assert [task.task_id for task in store.load_all()] == ["legacy"]
+
+    store.delete("legacy")
+    assert (
+        SqliteTaskMementoStore(
+            db_path,
+            legacy_json_path=legacy_path,
+        ).load_all()
+        == []
+    )
+
+
+def _task(task_id: str, state: DownloadState) -> TaskMemento:
+    return TaskMemento(
+        task_id=task_id,
+        state=state,
+        release=AnimeRelease(
+            title="[ANi] 葬送的芙莉莲 - 01 [1080P][Baha][WEB-DL][AAC AVC][CHT][MP4]",
+            download_url=f"magnet:?xt=urn:btih:{task_id}",
+            anime_name="葬送的芙莉莲",
+            season=1,
+            episode=1,
+            fansub="ANi",
+            quality=VideoQuality.Q1080P,
+            languages=[LanguageType.CHT],
+        ),
+        base_path="/anime",
+    )

--- a/tests/application/anime_library_ingestion/test_filters.py
+++ b/tests/application/anime_library_ingestion/test_filters.py
@@ -18,9 +18,20 @@ class FakeRepository:
     def __init__(self, records=None):
         self.records = records or []
 
-    async def find_releases_by_episode(self, anime_name, season, episode):
+    async def find_releases_by_episodes(self, keys):
         await asyncio.sleep(0)
-        return self.records
+        return {key: self.records for key in keys}
+
+
+class BulkOnlyRepository:
+    def __init__(self, records_by_key=None):
+        self.records_by_key = records_by_key or {}
+        self.batch_calls = []
+
+    async def find_releases_by_episodes(self, keys):
+        await asyncio.sleep(0)
+        self.batch_calls.append(tuple(keys))
+        return {key: self.records_by_key.get(key, []) for key in keys}
 
 
 def _release(
@@ -111,6 +122,29 @@ async def test_priority_filter_skips_lower_priority_existing_episode():
     assert result == []
 
 
+async def test_priority_filter_prefetches_episode_records_in_bulk():
+    repo = BulkOnlyRepository(
+        {
+            ("Test Anime", 1, 1): [
+                {
+                    "fansub": "Sub_A",
+                    "quality": "1080p",
+                    "languages": "简",
+                    "version": 1,
+                }
+            ]
+        }
+    )
+
+    result = await PriorityFilter(
+        PrioritySettings(fansub=["Sub_A", "Sub_B"], quality=[]),
+        repo,
+    ).apply([_release(fansub="Sub_B")])
+
+    assert result == []
+    assert repo.batch_calls == [(("Test Anime", 1, 1),)]
+
+
 async def test_strict_filter_allows_version_upgrade_for_same_rename_stem():
     repo = FakeRepository(
         [
@@ -128,3 +162,26 @@ async def test_strict_filter_allows_version_upgrade_for_same_rename_stem():
     ).apply([_release(version=2)])
 
     assert [entry.version for entry in result] == [2]
+
+
+async def test_strict_filter_prefetches_episode_records_in_bulk():
+    repo = BulkOnlyRepository(
+        {
+            ("Test Anime", 1, 1): [
+                {
+                    "fansub": "Sub_A",
+                    "quality": "1080p",
+                    "languages": "简",
+                    "version": 1,
+                }
+            ]
+        }
+    )
+
+    result = await StrictRenameFilter(
+        "{anime_name} S{season:02d}E{episode:02d} {fansub} {quality} {languages}",
+        repo,
+    ).apply([_release()])
+
+    assert result == []
+    assert repo.batch_calls == [(("Test Anime", 1, 1),)]

--- a/tests/application/anime_library_ingestion/test_pipeline.py
+++ b/tests/application/anime_library_ingestion/test_pipeline.py
@@ -333,6 +333,53 @@ async def test_rss_stage_enqueues_unique_download_candidates(tmp_path, isolated_
     await event_manager.stop()
 
 
+async def test_rss_stage_prefilter_finds_existing_candidate_titles_in_bulk(
+    tmp_path, isolated_db
+):
+    class BulkRepository:
+        def __init__(self):
+            self.calls = []
+
+        def find_existing_titles(self, candidate_titles):
+            self.calls.append(tuple(candidate_titles))
+            return asyncio.sleep(0, {"Already Downloaded"})
+
+        def is_downloaded(self, title):
+            raise AssertionError("single-title lookup should not be used")
+
+    event_manager = OAniEventManager()
+    await event_manager.start()
+    repository = BulkRepository()
+    stage = RSSStage(
+        feed_reader=FakeFeedReader([]),
+        metadata_parser=PassingMetadataParser(),
+        metadata_validator=PassingMetadataValidator(),
+        anime_library_repository=repository,
+        output_buffer=PipelineBuffer("download"),
+        event_publisher=event_manager,
+        filter_chain=FilterChain([]),
+        settings=AnimeLibraryIngestionSettings(
+            download_path="/anime",
+            rename_format="{anime_name} S{season:02d}E{episode:02d}",
+            rss_interval_seconds=0,
+        ),
+        interval_seconds=0,
+        task_reservation=RecordingTaskReservation(),
+    )
+
+    accepted, summary = await stage._filter_downloaded(
+        [
+            AnimeRelease(title="Already Downloaded", download_url="magnet:?old"),
+            AnimeRelease(title="New Release", download_url="magnet:?new"),
+        ]
+    )
+
+    assert [entry.title for entry in accepted] == ["New Release"]
+    assert repository.calls == [("Already Downloaded", "New Release")]
+    assert summary == "already_downloaded=1"
+    await event_manager.stop()
+
+
 async def test_rss_stage_validates_parsed_metadata_before_enrichment(
     tmp_path, isolated_db
 ):

--- a/tests/assistant/test_loop.py
+++ b/tests/assistant/test_loop.py
@@ -19,6 +19,7 @@ from openlist_ani.assistant.core.models import (
     ToolCall,
 )
 from openlist_ani.assistant.memory.manager import MemoryManager
+from openlist_ani.assistant.tool.builtin.send_message_tool import SendMessageTool
 from openlist_ani.assistant.tool.registry import ToolRegistry
 
 from .conftest import MockProvider, ReadOnlyTool, WriteTool
@@ -199,6 +200,39 @@ class TestAgenticLoop:
         tool_messages = [m for m in second_call_messages if m.role == Role.TOOL]
         assert len(tool_messages) >= 1
         assert tool_messages[-1].tool_results[0].content == "found matches"
+
+    @pytest.mark.asyncio
+    async def test_send_message_tool_emits_intermediate_message_event(self, memory):
+        """send_message should be visible to frontends as a consumable event."""
+        registry = ToolRegistry()
+        registry.register(SendMessageTool())
+        provider = MockProvider(
+            [
+                ProviderResponse(
+                    tool_calls=[
+                        ToolCall(
+                            id="tc_send",
+                            name="send_message",
+                            arguments={"message": "Still working..."},
+                        )
+                    ],
+                ),
+                ProviderResponse(text="Done."),
+            ]
+        )
+        context = ContextBuilder(memory)
+        loop = AgenticLoop(provider, registry, context, memory)
+
+        events = []
+        async for event in loop.process("long task"):
+            events.append(event)
+
+        assert any(
+            event.type == EventType.INTERMEDIATE_MESSAGE
+            and event.text == "Still working..."
+            for event in events
+        )
+        assert _collect_text(events) == "Done."
 
     @pytest.mark.asyncio
     async def test_session_persistence(self, memory, registry, tmp_path):

--- a/tests/assistant/test_messaging_frontend.py
+++ b/tests/assistant/test_messaging_frontend.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import tempfile
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -179,3 +180,25 @@ async def test_active_turn_enqueues_pending_message(tmp_path):
     await frontend.handle_inbound(_message("interrupt"))
 
     assert loop.message_queue.has_pending_prompts() is True
+
+
+@pytest.mark.asyncio
+async def test_shutdown_closes_cached_chat_loops(tmp_path):
+    messenger = FakeMessenger()
+    loop_a = _make_loop(tmp_path / "a")
+    loop_b = _make_loop(tmp_path / "b")
+    closed = []
+
+    loop_a.shutdown = AsyncMock(side_effect=lambda: closed.append("a"))
+    loop_b.shutdown = AsyncMock(side_effect=lambda: closed.append("b"))
+    frontend = MessagingFrontend(
+        platform="wechat",
+        messenger=messenger,
+        loop=loop_a,
+    )
+    frontend._chat_loops = {"chat-a": loop_a, "chat-b": loop_b}
+
+    await frontend.shutdown()
+
+    assert closed == ["a", "b"]
+    assert frontend._chat_loops == {}

--- a/tests/assistant/test_oani_parse_rss_skill.py
+++ b/tests/assistant/test_oani_parse_rss_skill.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from openlist_ani.builtin_skills.skills.oani.script import parse_rss
+
+
+class FakeBackendClient:
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url
+        self.closed = False
+        long_url = "magnet:?xt=urn:btih:" + ("a" * 80) + "&dn=episode"
+        self.parse_rss = AsyncMock(
+            return_value={
+                "success": True,
+                "total": 1,
+                "entries": [
+                    {
+                        "index": 0,
+                        "title": "Example Anime - 01",
+                        "download_url": long_url,
+                        "fansub": "ANi",
+                        "quality": "1080p",
+                        "languages": ["繁"],
+                    }
+                ],
+            }
+        )
+        self.close = AsyncMock(side_effect=self._mark_closed)
+
+    def _mark_closed(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_parse_rss_skill_keeps_full_download_url(monkeypatch):
+    monkeypatch.setattr(parse_rss, "BackendClient", FakeBackendClient)
+    monkeypatch.setattr(parse_rss, "config", SimpleNamespace(backend_url="https://api"))
+
+    result = await parse_rss.run(url="https://example.test/rss")
+
+    expected_url = "magnet:?xt=urn:btih:" + ("a" * 80) + "&dn=episode"
+    assert expected_url in result
+    assert expected_url[:60] + "…" not in result


### PR DESCRIPTION
## Background

The ingestion pipeline now handles larger RSS batches and OpenList polling pressure more efficiently, and the assistant messaging frontends need to consume intermediate send-message events consistently across CLI and messaging transports.

## Description

- Add short-lived OpenList task snapshot caching shared across concurrent download workflows to reduce redundant task-list polling while invalidating snapshots after new submissions.
- Add SQLite-backed task memento persistence and bulk existing-title lookup support for RSS filtering and priority/strict filters.
- Improve assistant messaging behavior so `send_message` tool calls emit intermediate messages through loop events and messaging frontends can shut down active loops cleanly.
- Keep oani RSS parsing output complete by preserving full download URLs.

## Detailed Plan

The download workflow keeps per-task temporary directories and still treats OpenList task state as the source of truth. The new cache only memoizes short-lived task-list snapshots and uses generation invalidation so an in-flight stale fetch is not stored after a new task is submitted.

RSS filtering now asks the library repository for existing titles in bulk before per-entry filtering, reducing repeated database lookups without changing title-based duplicate semantics. Persistence changes are isolated behind repository/task memento ports so the application stages continue using domain-facing interfaces.

For assistant messaging, `send_message` no longer requires a direct callback. The agent loop emits an `INTERMEDIATE_MESSAGE` event after a successful tool result, and messaging frontends forward that event immediately while still collecting the final response.

## Testing and Verification

- [x] Required automated tests were run
- [x] Required static checks were run
- [x] Changes involving external services, configuration, or secrets were verified in a safe environment

Commands run locally:

- `uv lock --check` - passed
- `uv run ruff check .` - passed
- `uv run black --check .` - passed
- `uv run pytest -q` - `756 passed in 7.83s`
- `uv build --out-dir dist` - built sdist and wheel successfully
- `git diff --check` - passed

Runtime verification:

- Ran `uv run openlist-ani` against the configured OpenList debug path after clearing local `logs/`, `data/`, and remote `/PikPak/Debug`.
- Ran `uv run openlist-ani-assistant --cli` and verified `oani.list_downloads` plus `oani.query_library` skill/tool calls.
- The backend e2e exposed one OpenList/PikPak-side download artifact issue for a LoliHouse release (`Could not detect downloaded file`); assistant tool calls completed normally.

## Configuration and Documentation

- [x] Relevant documentation was updated, or no documentation update is needed
- [x] Example configuration is consistent with actual configuration options

No user-facing configuration changes are required.

## Compatibility and Risk

- [x] Backward compatibility was assessed
- [x] Main risks and rollback steps were documented

The changes are backward compatible at the public configuration level. Main risks are around task persistence migration and OpenList polling behavior; both are covered by focused unit tests. Rollback is the single commit in this branch.

## Screenshots or Logs

Local verification summary:

```text
uv run pytest -q
756 passed in 7.83s
```
