### PR TITLE
chore(release): bump version to v1.0.0.dev260517

### DIFF
--- a/docs/源码编译指南.md
+++ b/docs/源码编译指南.md
@@ -47,7 +47,7 @@ git fetch --tags
 git tag --sort=-v:refname
 
 # 切换到指定版本（将版本号替换为 Release 页面中的版本号）
-git checkout tags/v1.0.0.dev260426
+git checkout tags/v1.0.0.dev260517
 ```
 
 ## 第三步：安装依赖

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openlist-ani"
-version = "1.0.0.dev260426"
+version = "1.0.0.dev260517"
 description = "Automatically fetch anime updates from RSS feeds and download them offline to the corresponding cloud storage via OpenList."
 readme = "README.md"
 authors = [{ name = "TwoSix", email = "nitiaob@qq.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "openlist-ani"
-version = "1.0.0.dev260426"
+version = "1.0.0.dev260517"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Background

Prepare the 2026-05-17 release version `v1.0.0.dev260517`.

## Description

- Bump the package version to `1.0.0.dev260517` in `pyproject.toml` and `uv.lock`.
- Update the source build guide release tag example to `v1.0.0.dev260517`.

## Detailed Plan

This PR only prepares the version metadata and documentation example. After CI passes and this merges to `master`, the release tag and version branch will use the existing release format `v1.0.0.dev260517`.

## Testing and Verification

- [x] Required automated tests were run: `uv run --frozen pytest -q` (756 passed)
- [x] Required static checks were run: `uv lock --check`, `uv run --frozen ruff check .`, `uv run --frozen black --check .`, `git diff --check`
- [x] Package build was verified: `uv build --out-dir /tmp/openlist-ani-dist-260517`
- [x] Changes involving external services, configuration, or secrets were verified in a safe environment: N/A

## Configuration and Documentation

- [x] Relevant documentation was updated, or no documentation update is needed
- [x] Example configuration is consistent with actual configuration options: N/A

## Compatibility and Risk

- [x] Backward compatibility was assessed
- [x] Main risks and rollback steps were documented

Compatibility risk is low; this is a version metadata and documentation-only release prep. Rollback is reverting the version bump commit before publishing the tag.

## Screenshots or Logs

N/A