### PR TITLE
Avoid filtering normal episode releases as collections

### DIFF
--- a/src/openlist_ani/adapters/inbound/http/schema.py
+++ b/src/openlist_ani/adapters/inbound/http/schema.py
@@ -142,8 +142,6 @@ class ResolveMagnetResponse(BaseModel):
     )
     file_count: int | None = None
     files: list[ResolveMagnetFile] = Field(default_factory=list)
-    is_collection: bool = False
-    collection_reason: str | None = None
 
 
 # ── resolve_torrent ──────────────────────────────────────────────────
@@ -171,5 +169,3 @@ class ResolveTorrentResponse(BaseModel):
     )
     file_count: int | None = None
     files: list[ResolveMagnetFile] = Field(default_factory=list)
-    is_collection: bool = False
-    collection_reason: str | None = None

--- a/src/openlist_ani/adapters/inbound/http/service.py
+++ b/src/openlist_ani/adapters/inbound/http/service.py
@@ -62,8 +62,6 @@ def _build_magnet_response(result) -> ResolveMagnetResponse:
         source=result.source,
         file_count=result.file_count,
         files=[ResolveMagnetFile(name=f.name, size=f.size) for f in result.files],
-        is_collection=result.is_collection,
-        collection_reason=result.collection_reason,
     )
 
 

--- a/src/openlist_ani/adapters/outbound/torrent_metadata/__init__.py
+++ b/src/openlist_ani/adapters/outbound/torrent_metadata/__init__.py
@@ -1,25 +1,21 @@
 """Magnet-link resolution helpers (libtorrent-backed)."""
 
 from .resolver import (
-    CollectionDetector,
     LibtorrentMetadataClient,
     MagnetResolver,
     ResolveResult,
     TorrentFile,
     TorrentFileResolver,
-    detect_collection,
     resolve_magnet,
     resolve_torrent,
 )
 
 __all__ = [
-    "CollectionDetector",
     "LibtorrentMetadataClient",
     "MagnetResolver",
     "ResolveResult",
     "TorrentFile",
     "TorrentFileResolver",
-    "detect_collection",
     "resolve_magnet",
     "resolve_torrent",
 ]

--- a/src/openlist_ani/adapters/outbound/torrent_metadata/resolver.py
+++ b/src/openlist_ani/adapters/outbound/torrent_metadata/resolver.py
@@ -1,4 +1,4 @@
-"""Magnet-link resolver: extract title and detect collection torrents.
+"""Magnet-link resolver: extract torrent titles and file metadata.
 
 Two-stage flow:
 
@@ -8,11 +8,6 @@ Two-stage flow:
    via libtorrent (DHT + trackers).  Wrapped in :func:`asyncio.to_thread`
    so the async router stays non-blocking.
 
-The resolver also flags *collection* resources by matching the title
-against a set of well-known keywords (合集 / 全集 / Complete / Batch /
-``\\d+-\\d+`` ranges …).  Callers must surface this to the user and
-abort, because the OpenList-Ani downloader cannot currently rename
-multi-episode payloads.
 """
 
 from __future__ import annotations
@@ -25,7 +20,6 @@ from urllib.parse import parse_qs, unquote, urlparse
 
 import aiohttp
 
-from openlist_ani.domain.anime_release import detect_collection
 from openlist_ani.logger import logger
 
 # Cap a downloaded .torrent file at 10 MiB — real torrents are a few KiB
@@ -57,8 +51,6 @@ class ResolveResult:
     source: str | None = None  # "dn" | "metadata" | None
     file_count: int | None = None
     files: list[TorrentFile] = field(default_factory=list)
-    is_collection: bool = False
-    collection_reason: str | None = None
 
 
 # ── Magnet ``dn`` extraction ─────────────────────────────────────────
@@ -255,11 +247,6 @@ def _fetch_metadata_blocking(
 # ── Resolver collaborators ───────────────────────────────────────────
 
 
-class CollectionDetector:
-    def detect(self, title: str) -> tuple[bool, str | None]:
-        return detect_collection(title)
-
-
 class LibtorrentMetadataClient:
     async def fetch_magnet_metadata(
         self, magnet: str, metadata_timeout: float
@@ -278,10 +265,8 @@ class MagnetResolver:
     def __init__(
         self,
         metadata_client: LibtorrentMetadataClient | None = None,
-        collection_detector: CollectionDetector | None = None,
     ) -> None:
         self._metadata_client = metadata_client or LibtorrentMetadataClient()
-        self._collection_detector = collection_detector or CollectionDetector()
 
     async def resolve(
         self, magnet: str, metadata_timeout: float = 30.0
@@ -294,14 +279,11 @@ class MagnetResolver:
 
         dn_title = _extract_dn(magnet)
         if dn_title:
-            is_coll, reason = self._collection_detector.detect(dn_title)
             return ResolveResult(
                 success=True,
                 message="Resolved title from magnet 'dn=' parameter.",
                 title=dn_title,
                 source="dn",
-                is_collection=is_coll,
-                collection_reason=reason,
             )
 
         logger.debug(
@@ -331,7 +313,6 @@ class MagnetResolver:
                 ),
             )
 
-        is_coll, reason = self._collection_detector.detect(name)
         return ResolveResult(
             success=True,
             message="Resolved title from torrent metadata.",
@@ -339,8 +320,6 @@ class MagnetResolver:
             source="metadata",
             file_count=len(files),
             files=files,
-            is_collection=is_coll,
-            collection_reason=reason,
         )
 
 
@@ -426,10 +405,8 @@ class TorrentFileResolver:
     def __init__(
         self,
         metadata_client: LibtorrentMetadataClient | None = None,
-        collection_detector: CollectionDetector | None = None,
     ) -> None:
         self._metadata_client = metadata_client or LibtorrentMetadataClient()
-        self._collection_detector = collection_detector or CollectionDetector()
 
     async def resolve(self, url: str) -> ResolveResult:
         if not _looks_like_torrent_url(url):
@@ -459,7 +436,6 @@ class TorrentFileResolver:
                 ),
             )
 
-        is_coll, reason = self._collection_detector.detect(name)
         return ResolveResult(
             success=True,
             message="Resolved title from .torrent file metadata.",
@@ -467,8 +443,6 @@ class TorrentFileResolver:
             source="torrent_file",
             file_count=len(files),
             files=files,
-            is_collection=is_coll,
-            collection_reason=reason,
         )
 
 

--- a/src/openlist_ani/builtin_skills/skills/anime-download/SKILL.md
+++ b/src/openlist_ani/builtin_skills/skills/anime-download/SKILL.md
@@ -81,8 +81,6 @@ confirmation message.
    one.
 3. The resolved title plus the original magnet form a single
    candidate.
-4. Trust the resolver's `is_collection` flag — if true, refuse this
-   candidate per *Collection rejection* below.
 
 ### 1b′. User gave a .torrent file URL
 
@@ -95,8 +93,6 @@ A `.torrent` URL looks like `http(s)://…/*.torrent` (e.g. Mikan's
    the resource title.** Do not invent one.
 3. The resolved title plus the original .torrent URL form a single
    candidate.
-4. Trust the resolver's `is_collection` flag — if true, refuse this
-   candidate per *Collection rejection* below.
 
 ### 1c. User gave only a description (anime / episode / fansub / …)
 
@@ -116,17 +112,14 @@ season numbers, or version (v2). Same episode number across releases
 matching the user's preference. Never assume one release equals one
 episode.
 
-### Collection rejection (applies to 1a / 1b / 1c)
+### Collection rejection (applies to 1a / 1b / 1b′ / 1c)
 
-For magnet candidates, trust `oani/resolve_magnet`'s `is_collection`
-field — do not re-derive it from title keywords. For RSS / Mikan
-entries (which lack the flag), only refuse on unambiguous markers:
+Only refuse on unambiguous markers:
 `合集`, `全集`, `Complete`, `Batch`, `BD BOX`, `S\d+ Complete`, or
 zero-padded ranges like `01-12`. Naked numbers such as `Season 2 - 14`
 are NOT collections.
 
-When refusing, quote the resolver's `collection_reason` verbatim (or
-the matched marker for RSS / Mikan) and tell the user:
+When refusing, quote the matched marker and tell the user:
 
 > OpenList-Ani does not currently support downloading collection
 > releases (matched: `<reason>`). Please supply a single-episode link

--- a/src/openlist_ani/builtin_skills/skills/oani/SKILL.md
+++ b/src/openlist_ani/builtin_skills/skills/oani/SKILL.md
@@ -29,8 +29,8 @@ Openlist-Ani backend API reference.
 - **parse_rss**: Fetch + parse an RSS feed via the backend, returning each
   entry's `title` + `download_url`. Use when the user supplies an RSS URL.
 - **resolve_magnet**: Resolve a magnet link to its real `title` (via `dn=` or
-  libtorrent metadata) and detect collection releases. Use before calling
-  `create_download` whenever a magnet's real title is not already known.
+  libtorrent metadata). Use before calling `create_download` whenever a
+  magnet's real title is not already known.
 - **resolve_torrent**: Resolve a `.torrent` file URL (http / https) to its
   real `title` and file list by downloading the blob and parsing it with
   libtorrent. Use before calling `create_download` whenever the user

--- a/src/openlist_ani/builtin_skills/skills/oani/script/resolve_magnet.py
+++ b/src/openlist_ani/builtin_skills/skills/oani/script/resolve_magnet.py
@@ -1,9 +1,9 @@
-"""Resolve a magnet link to its real title and detect collection releases.
+"""Resolve a magnet link to its real title.
 
 Calls the backend ``/api/resolve_magnet`` endpoint.  The backend tries
 the magnet's ``dn=`` parameter first, then falls back to libtorrent
-metadata (DHT/peers, time-bounded).  The response also flags collection
-torrents — the assistant must NOT enqueue those.
+metadata (DHT/peers, time-bounded).  Collection filtering is handled
+outside the resolver.
 """
 
 from openlist_ani.assistant.skill_support.oani_backend_client import BackendClient
@@ -37,8 +37,6 @@ async def run(
     success = data.get("success", False)
     title = data.get("title")
     source = data.get("source") or "?"
-    is_collection = data.get("is_collection", False)
-    reason = data.get("collection_reason")
     file_count = data.get("file_count")
     msg = data.get("message", "")
 
@@ -55,21 +53,13 @@ async def run(
     if file_count is not None:
         lines.append(f"Files: {file_count}")
 
-    if is_collection:
-        lines += [
-            "",
-            f"COLLECTION DETECTED (matched: '{reason}').",
-            "OpenList-Ani does not currently support downloading collection "
-            "releases. Tell the user and DO NOT call oani/create_download.",
-        ]
-    else:
-        lines += [
-            "",
-            "Next: confirm with the user (download URL + title), check the "
-            "library for duplicates via oani/query_library, then call "
-            "oani/create_download(download_url=<magnet>, title=<Title>). "
-            "Pass the title verbatim — it is used by the backend to rename "
-            "the file. Do NOT modify or fabricate it.",
-        ]
+    lines += [
+        "",
+        "Next: confirm with the user (download URL + title), check the "
+        "library for duplicates via oani/query_library, then call "
+        "oani/create_download(download_url=<magnet>, title=<Title>). "
+        "Pass the title verbatim — it is used by the backend to rename "
+        "the file. Do NOT modify or fabricate it.",
+    ]
 
     return "\n".join(lines)

--- a/src/openlist_ani/builtin_skills/skills/oani/script/resolve_torrent.py
+++ b/src/openlist_ani/builtin_skills/skills/oani/script/resolve_torrent.py
@@ -1,4 +1,4 @@
-"""Resolve a .torrent file URL to its real title and detect collections.
+"""Resolve a .torrent file URL to its real title.
 
 Calls the backend ``/api/resolve_torrent`` endpoint, which downloads
 the .torrent file (size- and time-bounded) and parses its metadata
@@ -36,8 +36,6 @@ async def run(
     success = data.get("success", False)
     title = data.get("title")
     source = data.get("source") or "?"
-    is_collection = data.get("is_collection", False)
-    reason = data.get("collection_reason")
     file_count = data.get("file_count")
     msg = data.get("message", "")
 
@@ -54,21 +52,13 @@ async def run(
     if file_count is not None:
         lines.append(f"Files: {file_count}")
 
-    if is_collection:
-        lines += [
-            "",
-            f"COLLECTION DETECTED (matched: '{reason}').",
-            "OpenList-Ani does not currently support downloading collection "
-            "releases. Tell the user and DO NOT call oani/create_download.",
-        ]
-    else:
-        lines += [
-            "",
-            "Next: check the library for duplicates via oani/query_library, "
-            "confirm with the user (download URL + title), then call "
-            "oani/create_download(download_url=<torrent-url>, title=<Title>). "
-            "Pass the title verbatim — it is used by the backend to rename "
-            "the file. Do NOT modify or fabricate it.",
-        ]
+    lines += [
+        "",
+        "Next: check the library for duplicates via oani/query_library, "
+        "confirm with the user (download URL + title), then call "
+        "oani/create_download(download_url=<torrent-url>, title=<Title>). "
+        "Pass the title verbatim — it is used by the backend to rename "
+        "the file. Do NOT modify or fabricate it.",
+    ]
 
     return "\n".join(lines)

--- a/src/openlist_ani/domain/anime_release/collection.py
+++ b/src/openlist_ani/domain/anime_release/collection.py
@@ -9,9 +9,9 @@ import re
 _COLLECTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"合集"),
     re.compile(r"全集"),
-    re.compile(r"总集篇"),
     re.compile(r"全套"),
     re.compile(r"全\s*[0-9一二三四五六七八九十百两]+\s*(?:集|话|卷|季)"),
+    re.compile(r"(?<![\dA-Za-z])\d{1,3}\s*[~–—-]\s*\d{1,3}.*重新打包"),
     re.compile(r"(?:百度网盘|网盘)?打包下载"),
     re.compile(r"(?i)\bcomplete\b"),
     re.compile(
@@ -24,16 +24,17 @@ _COLLECTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bBATCH\b"),
     re.compile(r"(?i)BD[-\s]*BOX"),
     re.compile(r"(?i)\bTV\s*[+＋]\s*(?:OADs?|OVAs?|Movies?|剧场版)\b"),
-    re.compile(r"(?i)\bSeasons?\s*\d{1,2}\s*[~–—-]\s*\d{1,2}\b"),
+    re.compile(r"(?i)\bSeasons\s*\d{1,2}\s*[~–—-]\s*\d{1,2}\b"),
     re.compile(r"(?i)\bS\d{1,2}E\d{1,3}\s*[~–—-]\s*E?\d{1,3}\b"),
     re.compile(r"(?i)\bS(?:eason)?\s*\d{1,2}\s*Complete\b"),
+    re.compile(r"(?i)\bEP\s*0?\d{1,3}\s*[~–—-]\s*(?:EP\s*)?0?\d{1,3}\b"),
     re.compile(r"(?i)\b(?:Ep(?:isodes?)?|Eps?)\s*0?\d{1,3}\s*[~–—-]\s*\d{1,3}\b"),
-    re.compile(r"(?<![\dA-Za-z])\d{2,3}\s*[~–—-]\s*\d{2,3}(?!\d)"),
+    re.compile(r"(?<![0-9A-Za-z])0\d{1,2}\s*[~–—-]\s*0?\d{1,3}(?!\d)"),
+    re.compile(r"[\[【]\s*\d{1,3}\s*[~–—-]\s*\d{1,3}[^]】]*[\]】]"),
     re.compile(
-        r"(?i)(?<![\dA-Za-z])\d{1,3}\s*[~–—-]\s*\d{1,3}\s*\+\s*(?:OVA|OAD|SP|Movies?|剧场版)"
+        r"(?i)(?<![0-9A-Z])\d{1,3}\s*[~–—-]\s*\d{1,3}\s*\+\s*(?:OVA|OAD|SP|Movies?|剧场版)"
     ),
-    re.compile(r"(?i)(?<![\dA-Za-z])\d{1,3}\s*[~–—-]\s*\d{1,3}(?=\s*[\[(（])"),
-    re.compile(r"(?i)(?<![\dA-Za-z])\d{1,3}\s*[~–—-]\s*\d{1,3}\s*(?:end|fin|完)"),
+    re.compile(r"(?i)(?<![0-9A-Z])\d{1,3}\s*\+\s*(?:ES|SP|OVA|OAD)\s*0?\d{1,3}\b"),
 )
 
 

--- a/tests/adapters/outbound/torrent_metadata/test_resolver.py
+++ b/tests/adapters/outbound/torrent_metadata/test_resolver.py
@@ -1,56 +1,12 @@
-"""Tests for the magnet resolver: dn= parsing + collection detection."""
+"""Tests for the magnet resolver: dn= and metadata title extraction."""
 
 from __future__ import annotations
+
+import asyncio
 
 import pytest
 
 from openlist_ani.adapters.outbound.torrent_metadata import resolver as r
-
-
-class TestDetectCollection:
-    @pytest.mark.parametrize(
-        "title",
-        [
-            "[Sakurato] Anime Title 合集 [BDRip]",
-            "[字幕组] 番剧 全集",
-            "[Group] Show Complete BDRip",
-            "[Rare] 足球小将系列.1983-2018.Captain Tsubasa BATCH JP DVDRemux(比较全面）",
-            "Anime 01-24 [1080p]",
-            "Show S01E01-E12",
-            "Anime BD BOX",
-            "Show 总集篇 SP",
-            "【SW字幕组】[宠物小精灵 / 宝可梦 地平线 再度飞升][123-132][简日双语字幕][1080P][AVC][MP4][CHS_JP]",
-            "[天月搬运组][星球大战：异等小队/Star Wars: The Bad Batch 第一季][全16集][英语中字][1080P][Disney+]",
-            "[VCB-Studio] 青春之旅 / Ao Haru Ride / アオハライド 10-bit 1080p HEVC BDRip [TV + OAD Fin]",
-            "Black Butler Season 1-3 + OVA 1-6 (Sub) (1920x1080) [Phr0stY] [AnimeRG] <黑执事>",
-            "机械女神 Saber Marionette 银河醒目女 机械女神J+机械女神J to X+机械女神J again+机械女神R 全套DVDRIP 日英双音轨+外挂中文内挂英文字幕",
-            "娜娜/奈奈/世界上的另一个我 NANA -ナナ- 1-47 [DVDRip 1280x720 x264 FLAC]（2006年）重新打包",
-            "[Kamihikouki-Rip] 人鱼之森 人鱼の森 Ningyo no Mori 1-13+OVA (DVDRIP 1280x720 x264 AC3)（2003年）重新打包",
-            "[Ohys-Raws] 其中1个是妹妹!／三人行必有我妹 [BD 1280x720 x264 AAC] - 百度网盘打包下载",
-        ],
-    )
-    def test_positive(self, title):
-        is_coll, reason = r.detect_collection(title)
-        assert is_coll is True, title
-        assert reason
-
-    @pytest.mark.parametrize(
-        "title",
-        [
-            "[Sakurato] Anime Title - 01 [1080p]",
-            "[字幕组] 番剧 - 12 [简体][1080p]",
-            "Show S01E05 1080p",
-            "Anime - 03v2 [WebRip]",
-            "[黒ネズミたち] 宗门里除了我都是卧底 / Spy x Sect - 123 (B-Global Donghua 1920x1080 HEVC AAC MKV)",
-            "【枫叶字幕组】[宠物小精灵 / 宝可梦 地平线 再度飞升][123][简体][1080P][MP4]",
-            "[Group] Star Wars: The Bad Batch - 01 [1080P][CHS]",
-            "Show S02 - 14 [1080p]",
-            "[梦蓝字幕组]CrayonshinChan 蜡笔小新[2018.11.16][982][帮忙打包&爷爷来了哦][HDTV][简日][MP4]",
-        ],
-    )
-    def test_negative(self, title):
-        is_coll, _ = r.detect_collection(title)
-        assert is_coll is False, title
 
 
 class TestResolveMagnet:
@@ -71,10 +27,10 @@ class TestResolveMagnet:
         assert out.success is True
         assert out.title == "My Show - 01 [1080p]"
         assert out.source == "dn"
-        assert out.is_collection is False
+        assert not hasattr(out, "is_collection")
+        assert not hasattr(out, "collection_reason")
 
-    @pytest.mark.asyncio
-    async def test_dn_path_collection_flagged(self, monkeypatch):
+    async def test_dn_path_collection_title_is_not_classified(self, monkeypatch):
         monkeypatch.setattr(r, "_fetch_metadata_blocking", lambda *a, **kw: (None, []))
         m = (
             "magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567"
@@ -82,8 +38,9 @@ class TestResolveMagnet:
         )
         out = await r.resolve_magnet(m, metadata_timeout=5)
         assert out.success is True
-        assert out.is_collection is True
-        assert out.collection_reason
+        assert out.title == "Show Complete BDRip"
+        assert not hasattr(out, "is_collection")
+        assert not hasattr(out, "collection_reason")
 
     @pytest.mark.asyncio
     async def test_metadata_fallback_success(self, monkeypatch):
@@ -99,6 +56,8 @@ class TestResolveMagnet:
         assert out.title == "Show - 02 [WebRip]"
         assert out.source == "metadata"
         assert out.file_count == 1
+        assert not hasattr(out, "is_collection")
+        assert not hasattr(out, "collection_reason")
 
     @pytest.mark.asyncio
     async def test_metadata_timeout_no_dn(self, monkeypatch):
@@ -108,3 +67,28 @@ class TestResolveMagnet:
         assert out.success is False
         assert out.title is None
         assert out.message
+
+
+class FakeTorrentMetadataClient:
+    async def parse_torrent_blob(self, blob):
+        await asyncio.sleep(0)
+        return "Show Complete BDRip", [r.TorrentFile(name="Show Complete.mkv")]
+
+
+class TestResolveTorrent:
+    @pytest.mark.asyncio
+    async def test_torrent_file_title_is_not_classified(self, monkeypatch):
+        async def fake_download(url):
+            await asyncio.sleep(0)
+            return b"torrent-bytes", None
+
+        monkeypatch.setattr(r, "_download_torrent_bytes", fake_download)
+        resolver = r.TorrentFileResolver(metadata_client=FakeTorrentMetadataClient())
+
+        out = await resolver.resolve("https://example.invalid/show.torrent")
+
+        assert out.success is True
+        assert out.title == "Show Complete BDRip"
+        assert out.source == "torrent_file"
+        assert not hasattr(out, "is_collection")
+        assert not hasattr(out, "collection_reason")

--- a/tests/application/anime_library_ingestion/test_filters.py
+++ b/tests/application/anime_library_ingestion/test_filters.py
@@ -54,8 +54,8 @@ def _release(
     )
 
 
-async def test_regex_filter_excludes_collection_titles():
-    result = await RegexTitleFilter().apply(
+async def test_regex_filter_excludes_configured_title_patterns():
+    result = await RegexTitleFilter(["合集"]).apply(
         [
             _release(title="[Sub_A] Test Anime - 01 [1080p]"),
             _release(title="[Sub_A] Test Anime - 01-12 合集 [1080p]"),
@@ -65,7 +65,7 @@ async def test_regex_filter_excludes_collection_titles():
     assert [entry.title for entry in result] == ["[Sub_A] Test Anime - 01 [1080p]"]
 
 
-async def test_regex_filter_uses_collection_detector_for_non_regex_collection_titles():
+async def test_regex_filter_applies_builtin_collection_detection():
     result = await RegexTitleFilter().apply(
         [
             _release(title="[Sub_A] Test Anime - 01 [1080p]"),
@@ -81,8 +81,19 @@ async def test_regex_filter_uses_collection_detector_for_non_regex_collection_ti
     assert [entry.title for entry in result] == ["[Sub_A] Test Anime - 01 [1080p]"]
 
 
+async def test_regex_filter_accepts_season_episode_dash_titles():
+    title = (
+        "[ANi] Tsue to Tsurugi no Wistoria /  杖与剑的魔剑谭 "
+        "Season 2 - 18 [1080P][Baha][WEB-DL][AAC AVC][CHT][MP4]"
+    )
+
+    result = await RegexTitleFilter().apply([_release(title=title)])
+
+    assert [entry.title for entry in result] == [title]
+
+
 async def test_filter_chain_reports_skipped_counts():
-    chain = FilterChain([RegexTitleFilter()])
+    chain = FilterChain([RegexTitleFilter(["合集"])])
 
     result = await chain.apply(
         [

--- a/tests/domain/anime_release/test_collection.py
+++ b/tests/domain/anime_release/test_collection.py
@@ -1,0 +1,57 @@
+import pytest
+
+from openlist_ani.domain.anime_release import detect_collection
+
+
+class TestDetectCollection:
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "[Sakurato] Anime Title 合集 [BDRip]",
+            "[字幕组] 番剧 全集",
+            "[Group] Show Complete BDRip",
+            "[Rare] 足球小将系列.1983-2018.Captain Tsubasa BATCH JP DVDRemux(比较全面）",
+            "Anime 01-24 [1080p]",
+            "Show S01E01-E12",
+            "Anime BD BOX",
+            "【SW字幕组】[宠物小精灵 / 宝可梦 地平线 再度飞升][123-132][简日双语字幕][1080P][AVC][MP4][CHS_JP]",
+            "[天月搬运组][星球大战：异等小队/Star Wars: The Bad Batch 第一季][全16集][英语中字][1080P][Disney+]",
+            "[VCB-Studio] 青春之旅 / Ao Haru Ride / アオハライド 10-bit 1080p HEVC BDRip [TV + OAD Fin]",
+            "Black Butler Season 1-3 + OVA 1-6 (Sub) (1920x1080) [Phr0stY] [AnimeRG] <黑执事>",
+            "机械女神 Saber Marionette 银河醒目女 机械女神J+机械女神J to X+机械女神J again+机械女神R 全套DVDRIP 日英双音轨+外挂中文内挂英文字幕",
+            "娜娜/奈奈/世界上的另一个我 NANA -ナナ- 1-47 [DVDRip 1280x720 x264 FLAC]（2006年）重新打包",
+            "[Kamihikouki-Rip] 人鱼之森 人鱼の森 Ningyo no Mori 1-13+OVA (DVDRIP 1280x720 x264 AC3)（2003年）重新打包",
+            "[Ohys-Raws] 其中1个是妹妹!／三人行必有我妹 [BD 1280x720 x264 AAC] - 百度网盘打包下载",
+            "29岁单身中坚冒险家的日常 - EP01 ~ EP10 [简／繁] (1080p H.264 AAC SRTx2) {An Adventurer's Daily Grind at Age 29 | 29歳独身中坚冒険者の日常}",
+            "异世界四重奏3 - EP01~EP06 [简／繁] (1080p H.264 AAC2.0+DDP2.0 SRTx2) {异世界四重奏 | 异世界かるてっと}",
+            "【喵萌奶茶屋】★10月新番★[弹珠汽水瓶里的千岁同学 / 千歳くんはラムネ瓶のなか / Chitose-kun wa Ramune Bin no Naka][07+ES07][WebRip 1080p HEVC-10bit AAC][简繁日内封]",
+            '[芝士动物朋友] 「凭你也想讨伐魔王？」被勇者小队逐出队伍，只好在王都自在过活 / "Omae Gotoki ga Maou ni Kateru to Omouna" to Yuusha Party wo Tsuihou sareta node, Outo de Kimama ni Kurashitai / 「お前ごときが魔王に胜てると思うな」と勇者パーティを追放されたので、王都で気ままに暮らしたい / Omagoto [1-12][CR-WebRip 1080p HEVC AAC][简繁内封]【CR官译】',
+            "[芝士动物朋友] 转生之后的我变成了龙蛋 / Tensei Shitara Dragon no Tamago Datta / 転生したらドラゴンの卵だった [1-12][AMZN-WebRemux 1080p AVC EAC3 SRT][简繁内封]【CatchPlay官译】",
+        ],
+    )
+    def test_positive(self, title):
+        is_coll, reason = detect_collection(title)
+        assert is_coll is True, title
+        assert reason
+
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "[Sakurato] Anime Title - 01 [1080p]",
+            "[字幕组] 番剧 - 12 [简体][1080p]",
+            "Show S01E05 1080p",
+            "Anime - 03v2 [WebRip]",
+            "[黒ネズミたち] 宗门里除了我都是卧底 / Spy x Sect - 123 (B-Global Donghua 1920x1080 HEVC AAC MKV)",
+            "【枫叶字幕组】[宠物小精灵 / 宝可梦 地平线 再度飞升][123][简体][1080P][MP4]",
+            "[Group] Star Wars: The Bad Batch - 01 [1080P][CHS]",
+            "Show S02 - 14 [1080p]",
+            "[黒ネズミたち] Dr.STONE 新石纪 第四季 / Dr. Stone: Science Future Part 3 - 30 (Baha 1920x1080 AVC AAC MP4)",
+            "[LoliHouse] 异世界悠闲农家 2 / Isekai Nonbiri Nouka 2 - 05 [WebRip 1080p HEVC-10bit AAC][简繁内封字幕]",
+            "[黒ネズミたち] 链锯人 总集篇 / Chainsaw Man Recap - 02 (Baha 1920x1080 AVC AAC MP4)",
+            "[ANi] Tsue to Tsurugi no Wistoria /  杖与剑的魔剑谭 Season 2 - 18 [1080P][Baha][WEB-DL][AAC AVC][CHT][MP4]",
+            "[梦蓝字幕组]CrayonshinChan 蜡笔小新[2018.11.16][982][帮忙打包&爷爷来了哦][HDTV][简日][MP4]",
+        ],
+    )
+    def test_negative(self, title):
+        is_coll, _ = detect_collection(title)
+        assert is_coll is False, title


### PR DESCRIPTION
## Background

A collection detector false positive treated the numeric fragment in `Season 2 - 18` as an episode range. That caused a normal single-episode RSS item to be skipped as a collection. The intended design is that collection rejection belongs in the RSS filter, while the torrent metadata resolver should only resolve metadata.

## Description

- Move built-in collection rejection into the RSS regex filter.
- Remove collection detection and collection response fields from the torrent metadata resolver path.
- Tighten collection patterns so normal titles like `Season 2 - 18` are accepted.
- Detect bracketed numeric episode ranges such as `[1-12]` and `[01-12]` without matching bare title text ranges.
- Update built-in skill scripts and guidance to stop relying on resolver collection flags.
- Add regression tests for collection positives and normal episode negatives.

## Detailed Plan

The detector now keeps only higher-confidence collection markers, including explicit batch/complete markers, bracketed numeric ranges, `EP01~EP10` style ranges, and `S01E01-E12` style ranges. Broad bare numeric ranges are avoided because they can match normal season and episode fragments. Bare `总集篇` is also avoided because a recap can be a normal single-episode download.

The main tradeoff is intentional: prioritize precision over recall. A few low-confidence collection titles may pass the filter until they can be covered with patterns that have matching negative examples. The alternative of keeping resolver-level collection flags was rejected because it creates a second filtering stage and mixes metadata resolution with download filtering policy.

Affected areas: RSS filtering, torrent metadata resolver responses, inbound HTTP schemas, built-in skill scripts/docs, and tests.

## Testing and Verification

- `uv run pytest -q` -> 766 passed
- `OPENLIST_ANI_REPO_PATH=/home/twosix/code/Openlist-Ani uv run pytest -q` in `Openlist-Ani-metadata-eval` -> 12 passed
- `uv run ruff check . && uv run black --check src tests` -> passed
- Manual eval precision check -> 0 false positives on labeled manual gold titles
- Manual gold collection/range rejected detection -> 159 / 164 detected

- [x] Required automated tests were run
- [x] Required static checks were run
- [x] Changes involving external services, configuration, or secrets were verified in a safe environment

## Configuration and Documentation

No configuration changes are required. Built-in skill documentation and helper scripts were updated to match the new resolver/filter responsibility split.

- [x] Relevant documentation was updated, or no documentation update is needed
- [x] Example configuration is consistent with actual configuration options

## Compatibility and Risk

Breaking change: `resolve_magnet` and `resolve_torrent` responses no longer include `is_collection` or `collection_reason`.

Primary risk: some ambiguous collection releases may still pass until a high-confidence pattern is added. This is intentional to avoid false positives that would block normal downloads. Rollback is to revert this PR, or to add narrower follow-up patterns with explicit positive and negative eval coverage.

- [x] Backward compatibility was assessed
- [x] Main risks and rollback steps were documented

## Screenshots or Logs

N/A