### PR TITLE
Bump version to v1.0.0.dev260518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openlist-ani"
-version = "1.0.0.dev260517"
+version = "1.0.0.dev260518"
 description = "Automatically fetch anime updates from RSS feeds and download them offline to the corresponding cloud storage via OpenList."
 readme = "README.md"
 authors = [{ name = "TwoSix", email = "nitiaob@qq.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "openlist-ani"
-version = "1.0.0.dev260517"
+version = "1.0.0.dev260518"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Background

This is a hotfix release bump for the May 18 release. It follows the existing date-based development version pattern after `v1.0.0.dev260517`.

## Description

- Bump `pyproject.toml` from `1.0.0.dev260517` to `1.0.0.dev260518`
- Refresh `uv.lock` so the editable package version matches the project version

## Detailed Plan

After this PR is merged, create the matching `v1.0.0.dev260518` branch and tag from `master`, then create a draft GitHub release copied from the previous release notes with a hotfix notice at the top.

## Testing and Verification

- `uv lock --check` -> passed
- `uv run pytest -q` -> 766 passed
- `uv run ruff check . && uv run black --check .` -> passed

- [x] Required automated tests were run
- [x] Required static checks were run
- [x] Changes involving external services, configuration, or secrets were verified in a safe environment

## Configuration and Documentation

No configuration changes are required.

- [x] Relevant documentation was updated, or no documentation update is needed
- [x] Example configuration is consistent with actual configuration options

## Compatibility and Risk

This PR only bumps the package version. Runtime behavior changes are already merged in PR #134. Rollback is to revert the version bump before publishing the release.

- [x] Backward compatibility was assessed
- [x] Main risks and rollback steps were documented

## Screenshots or Logs

N/A