### PR TITLE
feat(assistant): allow frontends to run together

### DIFF
--- a/src/openlist_ani/assistant/__init__.py
+++ b/src/openlist_ani/assistant/__init__.py
@@ -83,11 +83,7 @@ def _enabled_frontend_names(assistant_cfg: Any) -> list[str]:
 
 
 def _telegram_frontend_enabled(assistant_cfg: Any) -> bool:
-    non_telegram_enabled = assistant_cfg.wechat.enabled or assistant_cfg.feishu.enabled
-    return bool(
-        assistant_cfg.telegram.enabled
-        or (assistant_cfg.telegram.bot_token and not non_telegram_enabled)
-    )
+    return bool(assistant_cfg.telegram.enabled or assistant_cfg.telegram.bot_token)
 
 
 def _validate_frontend_config(assistant_cfg: Any) -> list[str]:

--- a/tests/assistant/test_assistant_frontend_config.py
+++ b/tests/assistant/test_assistant_frontend_config.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 from openlist_ani.adapters.outbound.configuration.settings import (
     AssistantConfig,
     FeishuAssistantConfig,
+    TelegramAssistantConfig,
     WechatAssistantConfig,
 )
-from openlist_ani.assistant import _validate_frontend_config
+from openlist_ani.assistant import (
+    _enabled_frontend_names,
+    _validate_frontend_config,
+)
 
 
 def test_validate_frontend_config_requires_wechat_setup_output():
@@ -39,3 +43,17 @@ def test_validate_frontend_config_requires_feishu_app_credentials():
 
     assert any("app_id" in error for error in errors)
     assert any("app_secret" in error for error in errors)
+
+
+def test_enabled_frontend_names_allow_telegram_and_wechat_to_coexist():
+    cfg = AssistantConfig(
+        telegram=TelegramAssistantConfig(bot_token="token"),
+        wechat=WechatAssistantConfig(
+            enabled=True,
+            account_id="bot@im.bot",
+            token="wechat-token",
+            home_channel="user@im.wechat",
+        ),
+    )
+
+    assert _enabled_frontend_names(cfg) == ["telegram", "wechat"]


### PR DESCRIPTION
## Background

The assistant should be able to run Telegram, Feishu, WeChat, and CLI frontends together when they are configured. The previous Telegram enablement check could be affected by other messaging frontend settings, so valid multi-frontend configurations did not always start as expected.

## Description

- Adjust frontend enablement so Telegram can coexist with other frontends
- Add `_enabled_frontend_names` to report the enabled frontend list consistently
- Add a regression test for Telegram and WeChat running together from configuration

## Detailed Plan

This PR only changes startup configuration decisions. Telegram enablement is based on the Telegram token, and other frontends no longer make Telegram mutually exclusive.

## Testing and Verification

- `uv run --frozen black --check .`: passed
- `uv run --frozen ruff check src/openlist_ani/assistant/__init__.py tests/assistant/test_assistant_frontend_config.py`: passed
- `uv run --frozen pytest tests/assistant/test_assistant_frontend_config.py -q`: 4 passed

- [x] Required automated tests were run
- [x] Required static checks were run
- [x] Changes involving external services, configuration, or secrets were verified in a safe environment

## Configuration and Documentation

N/A. This PR does not add new configuration options; it fixes the semantics of existing configuration combinations.

- [x] Relevant documentation was updated, or no documentation update is needed
- [x] Example configuration is consistent with actual configuration options

## Compatibility and Risk

No breaking changes. The main risk is exposing runtime combinations that were previously blocked by the incorrect frontend selection logic. Reverting this commit restores the previous mutually exclusive behavior.

- [x] Backward compatibility was assessed
- [x] Main risks and rollback steps were documented

## Screenshots or Logs

N/A. CI and SonarCloud results will be verified after the PR checks complete.