### PR TITLE
fix(assistant): process queued messages after active reply

### DIFF
--- a/src/openlist_ani/assistant/frontend/messaging.py
+++ b/src/openlist_ani/assistant/frontend/messaging.py
@@ -139,28 +139,51 @@ class MessagingFrontend(Frontend):
             f"active_turns={len(self._active_turns)}"
         )
         try:
-            final_parts: list[str] = []
-            async for event in loop.process(text):
-                if event.type == EventType.TEXT_DONE and event.text:
-                    final_parts.append(event.text)
-                elif event.type == EventType.ERROR and event.text:
-                    final_parts.append(f"Error: {event.text}")
-                elif event.type == EventType.INTERMEDIATE_MESSAGE and event.text:
-                    await self._messenger.send_text(message.target.chat_id, event.text)
-            response = "\n".join(final_parts).strip() or "No response."
-            await self._messenger.send_text(message.target.chat_id, response)
-            logger.info(f"{self.platform} response sent.")
-            logger.debug(
-                f"{self.platform} turn finished: session_key={session_key}, "
-                f"chat_id={message.target.chat_id}, final_parts={len(final_parts)}, "
-                f"final_chars={sum(len(part) for part in final_parts)}, "
-                f"elapsed_ms={int((time.monotonic() - turn_started_at) * 1000)}"
-            )
+            pending_texts = [text]
+            while pending_texts:
+                current_text = pending_texts.pop(0)
+                await self._process_single_turn(
+                    message,
+                    loop,
+                    current_text,
+                    session_key=session_key,
+                    turn_started_at=turn_started_at,
+                )
+                pending_texts.extend(
+                    pending.content for pending in loop.message_queue.drain_prompts()
+                )
         except Exception as exc:  # noqa: BLE001
             logger.error(f"{self.platform} frontend failed: {exc}")
             await self._messenger.send_text(message.target.chat_id, f"Error: {exc}")
         finally:
             self._active_turns.discard(session_key)
+
+    async def _process_single_turn(
+        self,
+        message: InboundMessage,
+        loop: AgenticLoop,
+        text: str,
+        *,
+        session_key: str,
+        turn_started_at: float,
+    ) -> None:
+        final_parts: list[str] = []
+        async for event in loop.process(text):
+            if event.type == EventType.TEXT_DONE and event.text:
+                final_parts.append(event.text)
+            elif event.type == EventType.ERROR and event.text:
+                final_parts.append(f"Error: {event.text}")
+            elif event.type == EventType.INTERMEDIATE_MESSAGE and event.text:
+                await self._messenger.send_text(message.target.chat_id, event.text)
+        response = "\n".join(final_parts).strip() or "No response."
+        await self._messenger.send_text(message.target.chat_id, response)
+        logger.info(f"{self.platform} response sent.")
+        logger.debug(
+            f"{self.platform} turn finished: session_key={session_key}, "
+            f"chat_id={message.target.chat_id}, final_parts={len(final_parts)}, "
+            f"final_chars={sum(len(part) for part in final_parts)}, "
+            f"elapsed_ms={int((time.monotonic() - turn_started_at) * 1000)}"
+        )
 
     async def _get_loop(self, message: InboundMessage) -> AgenticLoop:
         session_key = self._session_key(message)

--- a/src/openlist_ani/assistant/frontend/telegram.py
+++ b/src/openlist_ani/assistant/frontend/telegram.py
@@ -645,6 +645,27 @@ class TelegramFrontend(Frontend):
             return
 
         self._active_turns.add(chat_id)
+        try:
+            pending_texts = [message_text]
+            while pending_texts:
+                current_text = pending_texts.pop(0)
+                await self._process_single_turn(update, loop, current_text)
+                pending_texts.extend(
+                    pending.content for pending in loop.message_queue.drain_prompts()
+                )
+        except Exception as e:
+            logger.error(f"Error processing message: {e}")
+            await update.message.reply_text(f"Error: {e}")
+        finally:
+            self._active_turns.discard(chat_id)
+
+    async def _process_single_turn(
+        self,
+        update: Update,
+        loop: AgenticLoop,
+        message_text: str,
+    ) -> None:
+        chat_id = update.message.chat_id
         turn_started_at = time.monotonic()
         logger.debug(
             f"Telegram turn started: chat_id={chat_id}, chars={len(message_text)}, "
@@ -663,13 +684,11 @@ class TelegramFrontend(Frontend):
                 f"final_parts={len(final_parts)}, final_chars={final_chars}, "
                 f"elapsed_ms={elapsed_ms}"
             )
-        except Exception as e:
-            logger.error(f"Error processing message: {e}")
+        except Exception:
             await self._cleanup_status_message(status_msg)
-            await update.message.reply_text(f"Error: {e}")
+            raise
         finally:
             await self._stop_typing_indicator(typing_task)
-            self._active_turns.discard(chat_id)
 
     @staticmethod
     def _build_skill_message(

--- a/src/openlist_ani/assistant/frontend/textual_app/app.py
+++ b/src/openlist_ani/assistant/frontend/textual_app/app.py
@@ -814,7 +814,13 @@ class TextualFrontend(App):
                     f"response_chars={len(full_text)}, "
                     f"elapsed_ms={int(elapsed * 1000)}"
                 )
+            pending = self._agentic_loop.message_queue.drain_prompts()
             self._processing_task = None
+            if pending:
+                next_message = pending[0]
+                for queued in pending[1:]:
+                    self._agentic_loop.message_queue.enqueue(queued)
+                await self._start_turn(next_message.content)
             return
 
         if not event.text:

--- a/tests/assistant/test_loop.py
+++ b/tests/assistant/test_loop.py
@@ -1,5 +1,6 @@
 """Tests for the core agentic loop."""
 
+from collections.abc import AsyncGenerator
 import pytest
 from pathlib import Path
 
@@ -11,7 +12,9 @@ from openlist_ani.assistant.core.loop import (
     _is_transient,
 )
 from openlist_ani.assistant.core.cancellation import CancellationToken
+from openlist_ani.assistant.core.message_queue import MessageQueue, PendingMessage
 from openlist_ani.assistant.core.models import (
+    Message,
     EventType,
     LoopEvent,
     ProviderResponse,
@@ -23,6 +26,33 @@ from openlist_ani.assistant.tool.builtin.send_message_tool import SendMessageToo
 from openlist_ani.assistant.tool.registry import ToolRegistry
 
 from .conftest import MockProvider, ReadOnlyTool, WriteTool
+
+
+class QueueingTextProvider(MockProvider):
+    """Provider that queues a prompt while streaming a text-only response."""
+
+    def __init__(self, message_queue: MessageQueue) -> None:
+        super().__init__()
+        self._message_queue = message_queue
+        self._stream_call_count = 0
+
+    async def chat_completion_stream(
+        self,
+        messages: list[Message],
+        tools: list[dict] | None = None,
+        max_tokens_override: int | None = None,
+        temperature: float | None = None,
+    ) -> AsyncGenerator[ProviderResponse, None]:
+        self._calls.append((messages, tools))
+        self._stream_call_count += 1
+        if self._stream_call_count == 1:
+            self._message_queue.enqueue(
+                PendingMessage(content="queued while streaming")
+            )
+            yield ProviderResponse(text="The answer is ready.")
+        else:
+            yield ProviderResponse(text="Follow-up handled.")
+        yield ProviderResponse(stop_reason="stop")
 
 
 def _collect_text(events: list[LoopEvent]) -> str:
@@ -71,6 +101,32 @@ class TestAgenticLoop:
         types = [e.type for e in results]
         assert EventType.THINKING in types
         assert EventType.TEXT_DONE in types
+
+    @pytest.mark.asyncio
+    async def test_text_response_leaves_late_pending_prompt_for_followup(
+        self, memory, registry
+    ):
+        """Late prompts after the last tool checkpoint should remain queued."""
+        message_queue = MessageQueue()
+        provider = QueueingTextProvider(message_queue)
+        context = ContextBuilder(memory)
+        loop = AgenticLoop(
+            provider,
+            registry,
+            context,
+            memory,
+            message_queue=message_queue,
+        )
+
+        results = []
+        async for event in loop.process("What is the answer?"):
+            results.append(event)
+
+        assert [e.text for e in results if e.type == EventType.TEXT_DONE] == [
+            "The answer is ready."
+        ]
+        assert message_queue.has_pending_prompts()
+        assert len(provider._calls) == 1
 
     @pytest.mark.asyncio
     async def test_single_tool_call_round(self, memory, registry):

--- a/tests/assistant/test_messaging_frontend.py
+++ b/tests/assistant/test_messaging_frontend.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import tempfile
 from contextlib import contextmanager
 from io import StringIO
 from pathlib import Path
@@ -69,6 +68,10 @@ def _captured_log_messages():
 
 def _make_loop(tmp: Path, response: str = "assistant reply") -> AgenticLoop:
     provider = MockProvider([ProviderResponse(text=response)])
+    return _make_loop_with_provider(tmp, provider)
+
+
+def _make_loop_with_provider(tmp: Path, provider: MockProvider) -> AgenticLoop:
     registry = ToolRegistry()
     memory = MemoryManager(data_dir=tmp / "data", project_root=tmp / "proj")
     (tmp / "proj").mkdir(exist_ok=True)
@@ -80,6 +83,20 @@ def _make_loop(tmp: Path, response: str = "assistant reply") -> AgenticLoop:
         memory,
         session_storage=SessionStorage(tmp / "sessions"),
     )
+
+
+class BlockingProvider(MockProvider):
+    def __init__(self, responses: list[ProviderResponse]) -> None:
+        super().__init__(responses)
+        self.first_call_started = asyncio.Event()
+        self.release_first_call = asyncio.Event()
+
+    async def chat_completion_stream(self, *args, **kwargs):
+        if self._call_count == 0:
+            self.first_call_started.set()
+            await self.release_first_call.wait()
+        async for chunk in super().chat_completion_stream(*args, **kwargs):
+            yield chunk
 
 
 def _message(text: str, chat_id: str = "chat-1") -> InboundMessage:
@@ -251,20 +268,37 @@ async def test_rejected_telegram_command_does_not_log_content(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_active_turn_enqueues_pending_message(tmp_path):
+async def test_queued_message_after_final_text_is_processed_as_next_turn(tmp_path):
     messenger = FakeMessenger()
-    loop = _make_loop(Path(tempfile.mkdtemp()), response="first")
+    provider = BlockingProvider(
+        [
+            ProviderResponse(text="first reply"),
+            ProviderResponse(text="second reply"),
+        ]
+    )
+    loop = _make_loop_with_provider(tmp_path, provider)
     frontend = MessagingFrontend(
         platform="wechat",
         messenger=messenger,
         loop=loop,
         loop_factory=lambda: loop,
     )
-    frontend._active_turns.add("wechat:chat-1:user-1")
 
-    await frontend.handle_inbound(_message("interrupt"))
+    first_task = asyncio.create_task(frontend.handle_inbound(_message("first")))
+    await asyncio.wait_for(provider.first_call_started.wait(), timeout=1)
 
-    assert loop.message_queue.has_pending_prompts() is True
+    await frontend.handle_inbound(_message("second"))
+    provider.release_first_call.set()
+    await asyncio.wait_for(first_task, timeout=1)
+
+    assert messenger.sent == [
+        ("chat-1", "first reply"),
+        ("chat-1", "second reply"),
+    ]
+    assert not loop.message_queue.has_pending_prompts()
+    assert len(provider._calls) == 2
+    second_call_messages = provider._calls[1][0]
+    assert any(m.content == "second" for m in second_call_messages)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Background

When a user sent another message while the assistant was already replying, the message could miss the current tool-insertion window and remain queued until the user sent yet another message. That made messages appear delayed or attached to the wrong reply.

## Description

- Preserve pending message insertion between tool calls
- Leave messages queued when the current reply has already reached its final text phase
- Drain queued messages after the active reply is sent and immediately process them as follow-up turns
- Add behavior tests that gate message delivery rather than internal queue details

## Detailed Plan

The core loop continues to own pending prompts. Frontends now check the queue after sending the current response. If queued messages remain, the frontend starts follow-up turns in receive order so no user message waits for an unrelated future input.

## Testing and Verification

- `uv run --frozen black --check .`: passed
- `uv run --frozen ruff check src/openlist_ani/assistant/frontend/messaging.py src/openlist_ani/assistant/frontend/telegram.py src/openlist_ani/assistant/frontend/textual_app/app.py tests/assistant/test_loop.py tests/assistant/test_messaging_frontend.py`: passed
- `uv run --frozen pytest tests/assistant/test_loop.py tests/assistant/test_messaging_frontend.py tests/assistant/test_cli_frontend.py -q`: 38 passed

- [x] Required automated tests were run
- [x] Required static checks were run
- [x] Changes involving external services, configuration, or secrets were verified in a safe environment

## Configuration and Documentation

N/A. This PR does not change configuration or documentation.

- [x] Relevant documentation was updated, or no documentation update is needed
- [x] Example configuration is consistent with actual configuration options

## Compatibility and Risk

No breaking changes. The main risk is in frontend turn sequencing. The regression tests cover queued messages after the final-text phase being processed automatically as the next turn.

- [x] Backward compatibility was assessed
- [x] Main risks and rollback steps were documented

## Screenshots or Logs

N/A. CI and SonarCloud results will be verified after the PR checks complete.