### PR TITLE
chore(release): bump version to v1.0.0.dev260525

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openlist-ani"
-version = "1.0.0.dev260518"
+version = "1.0.0.dev260525"
 description = "Automatically fetch anime updates from RSS feeds and download them offline to the corresponding cloud storage via OpenList."
 readme = "README.md"
 authors = [{ name = "TwoSix", email = "nitiaob@qq.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -1038,7 +1038,7 @@ wheels = [
 
 [[package]]
 name = "openlist-ani"
-version = "1.0.0.dev260518"
+version = "1.0.0.dev260525"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## 摘要
- 将 openlist-ani 版本提升到 1.0.0.dev260525
- 同步更新 uv.lock 中的 editable package 版本

## 验证
- uv lock --check
- uv run --frozen ruff check .
- uv run --frozen black --check .
- uv run --frozen pytest -q
- uv build --out-dir dist
- docker build --file docker/Dockerfile --tag openlist-ani:ci .

## 发布说明
- CI 通过并合并后，将创建并推送 v1.0.0.dev260525 分支和同名 tag 作为发布存档。