### PR TITLE
feat(assistant): add Bangumi latest episode skill

### DIFF
--- a/src/openlist_ani/assistant/tool/builtin/skill_tool.py
+++ b/src/openlist_ani/assistant/tool/builtin/skill_tool.py
@@ -75,6 +75,7 @@ class SkillTool(BaseTool):
         _READ_ONLY_ACTIONS = {
             "search",
             "calendar",
+            "latest_episode",
             "query",
             "subgroups",
             "releases",

--- a/src/openlist_ani/builtin_skills/skills/bangumi/SKILL.md
+++ b/src/openlist_ani/builtin_skills/skills/bangumi/SKILL.md
@@ -16,6 +16,7 @@ Bangumi (bgm.tv) API reference.
 
 - **search**: Search anime/manga by keyword with filters (type, tag, date, rating).
 - **subject_detail**: Get full details for a specific Bangumi subject.
+- **latest_episode**: Get the latest aired main-story episode for a subject.
 - **calendar**: View the weekly anime airing schedule.
 - **related_subjects**: Find sequels, prequels, and related works.
 - **reviews**: Fetch community discussion topics and blog reviews for a subject.
@@ -38,3 +39,15 @@ Tell the user to set `[bangumi] access_token` in config.toml.
 
 Collection types: 1=wish(想看), 2=done(看过), 3=doing(在看), 4=on_hold(搁置), 5=dropped(抛弃)
 Subject types: 1=book, 2=anime, 3=music, 4=game, 6=real
+
+## Latest aired episode
+
+Use **latest_episode** when the user asks which episode of an anime is the
+latest/current aired episode. It needs a Bangumi subject ID. If the user gives
+only a title, call **search** first and then call **latest_episode** with the
+selected `subject_id`.
+
+This action uses Bangumi episode `airdate` and only considers main-story
+episodes (`type=0`). Bangumi provides date precision only, so it cannot
+distinguish whether today's episode has already reached its exact broadcast
+time.

--- a/src/openlist_ani/builtin_skills/skills/bangumi/SKILL.md
+++ b/src/openlist_ani/builtin_skills/skills/bangumi/SKILL.md
@@ -50,4 +50,4 @@ selected `subject_id`.
 This action uses Bangumi episode `airdate` and only considers main-story
 episodes (`type=0`). Bangumi provides date precision only, so it cannot
 distinguish whether today's episode has already reached its exact broadcast
-time.
+time. The action treats "today" as the current UTC+8 date.

--- a/src/openlist_ani/builtin_skills/skills/bangumi/script/latest_episode.py
+++ b/src/openlist_ani/builtin_skills/skills/bangumi/script/latest_episode.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 from openlist_ani.assistant.skill_support.bangumi_client import BangumiClient
@@ -19,14 +19,9 @@ def _parse_date(value: str) -> date | None:
         return None
 
 
-def _parse_as_of_date(value: str) -> date:
-    """Parse the optional reference date for deterministic latest-episode lookup."""
-    if not value:
-        return date.today()
-    parsed = _parse_date(value)
-    if parsed is None:
-        raise ValueError("as_of_date must use YYYY-MM-DD format")
-    return parsed
+def _today_utc8() -> date:
+    """Return today's date in Bangumi's fixed UTC+8 reference timezone."""
+    return datetime.now(timezone(timedelta(hours=8))).date()
 
 
 def _numeric(value: Any) -> float:
@@ -124,14 +119,12 @@ def _format_latest_episode(
 
 async def run(
     subject_id: str = "",
-    as_of_date: str = "",
     **kwargs,
 ) -> str:
     """Fetch the latest aired main-story episode for a Bangumi subject.
 
     Args:
         subject_id: Bangumi subject ID (required).
-        as_of_date: Optional reference date in YYYY-MM-DD format; defaults to today.
     """
     if not subject_id:
         return "Error: 'subject_id' parameter is required."
@@ -141,10 +134,7 @@ async def run(
     except ValueError:
         return "Error: 'subject_id' must be an integer."
 
-    try:
-        as_of = _parse_as_of_date(as_of_date)
-    except ValueError as exc:
-        return f"Error: {exc}"
+    as_of = _today_utc8()
 
     client = BangumiClient(access_token=config.bangumi_token)
     try:

--- a/src/openlist_ani/builtin_skills/skills/bangumi/script/latest_episode.py
+++ b/src/openlist_ani/builtin_skills/skills/bangumi/script/latest_episode.py
@@ -1,0 +1,164 @@
+"""Get the latest aired main-story episode for a Bangumi subject."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from openlist_ani.assistant.skill_support.bangumi_client import BangumiClient
+from openlist_ani.adapters.outbound.configuration import config
+
+
+def _parse_date(value: str) -> date | None:
+    """Parse a Bangumi date string, returning None for blank or invalid dates."""
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _parse_as_of_date(value: str) -> date:
+    """Parse the optional reference date for deterministic latest-episode lookup."""
+    if not value:
+        return date.today()
+    parsed = _parse_date(value)
+    if parsed is None:
+        raise ValueError("as_of_date must use YYYY-MM-DD format")
+    return parsed
+
+
+def _numeric(value: Any) -> float:
+    """Convert episode sort values to a stable numeric fallback."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _episode_date(episode: dict[str, Any]) -> date | None:
+    """Return the parsed episode airdate."""
+    return _parse_date(str(episode.get("airdate") or ""))
+
+
+def _find_latest_aired_episode(
+    episodes: list[dict[str, Any]],
+    as_of: date,
+) -> dict[str, Any] | None:
+    """Return the latest episode whose Bangumi airdate is on or before as_of."""
+    aired = [
+        episode
+        for episode in episodes
+        if (airdate := _episode_date(episode)) is not None and airdate <= as_of
+    ]
+    if not aired:
+        return None
+    return max(
+        aired,
+        key=lambda episode: (
+            _episode_date(episode) or date.min,
+            _numeric(episode.get("sort", episode.get("ep"))),
+            _numeric(episode.get("ep", episode.get("sort"))),
+            int(episode.get("id") or 0),
+        ),
+    )
+
+
+def _format_sort(value: Any) -> str:
+    """Format Bangumi numeric episode values without trailing .0."""
+    if value is None or value == "":
+        return ""
+    number = _numeric(value)
+    if number.is_integer():
+        return str(int(number))
+    return f"{number:g}"
+
+
+def _episode_number(episode: dict[str, Any]) -> str:
+    """Return the best human-facing episode number."""
+    return _format_sort(episode.get("ep")) or _format_sort(episode.get("sort")) or "?"
+
+
+def _episode_title(episode: dict[str, Any]) -> str:
+    """Return the best available title for an episode."""
+    return str(episode.get("name_cn") or episode.get("name") or "(untitled)")
+
+
+def _subject_name(subject: Any, subject_id: str) -> str:
+    """Return a stable display name for a subject-like object."""
+    return str(getattr(subject, "display_name", "") or f"ID:{subject_id}")
+
+
+def _format_no_episode(subject_name: str, as_of: date, episode_count: int) -> str:
+    """Format the no-aired-episode result."""
+    return "\n".join(
+        [
+            f"No aired main-story episodes found for {subject_name} as of {as_of.isoformat()}.",
+            f"Known main-story episodes: {episode_count}",
+            "Note: Bangumi episode airdate has date precision only; exact broadcast time is not available.",
+        ],
+    )
+
+
+def _format_latest_episode(
+    subject_name: str,
+    episode: dict[str, Any],
+    as_of: date,
+    episode_count: int,
+) -> str:
+    """Format the latest aired episode result for the assistant."""
+    airdate = episode.get("airdate") or ""
+    lines = [
+        f"# Latest aired episode for {subject_name}",
+        f"As of: {as_of.isoformat()}",
+        f"Episode: ep.{_episode_number(episode)}",
+        f"Episode ID: {episode.get('id', '')}",
+        f"Airdate: {airdate}",
+        f"Title: {_episode_title(episode)}",
+        f"Known main-story episodes: {episode_count}",
+        "Note: Bangumi episode airdate has date precision only; exact broadcast time is not available.",
+    ]
+    return "\n".join(lines)
+
+
+async def run(
+    subject_id: str = "",
+    as_of_date: str = "",
+    **kwargs,
+) -> str:
+    """Fetch the latest aired main-story episode for a Bangumi subject.
+
+    Args:
+        subject_id: Bangumi subject ID (required).
+        as_of_date: Optional reference date in YYYY-MM-DD format; defaults to today.
+    """
+    if not subject_id:
+        return "Error: 'subject_id' parameter is required."
+
+    try:
+        parsed_subject_id = int(subject_id)
+    except ValueError:
+        return "Error: 'subject_id' must be an integer."
+
+    try:
+        as_of = _parse_as_of_date(as_of_date)
+    except ValueError as exc:
+        return f"Error: {exc}"
+
+    client = BangumiClient(access_token=config.bangumi_token)
+    try:
+        subject = await client.fetch_subject(parsed_subject_id)
+        episodes = await client.fetch_subject_episodes(
+            parsed_subject_id, episode_type=0
+        )
+    except Exception as e:
+        return f"Error fetching latest episode for subject {subject_id}: {e}"
+    finally:
+        await client.close()
+
+    name = _subject_name(subject, subject_id)
+    latest = _find_latest_aired_episode(episodes, as_of)
+    if latest is None:
+        return _format_no_episode(name, as_of, len(episodes))
+    return _format_latest_episode(name, latest, as_of, len(episodes))

--- a/tests/assistant/test_bangumi_latest_episode_skill.py
+++ b/tests/assistant/test_bangumi_latest_episode_skill.py
@@ -1,0 +1,127 @@
+"""Tests for the Bangumi latest_episode builtin skill action."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from openlist_ani.assistant.skill.catalog import SkillCatalog
+
+
+def test_bangumi_catalog_exposes_latest_episode_action() -> None:
+    """The builtin Bangumi skill advertises latest_episode to the assistant."""
+    skills_dir = Path(__file__).parents[2] / "src/openlist_ani/builtin_skills/skills"
+    catalog = SkillCatalog(skills_dir)
+    catalog.discover()
+
+    bangumi = catalog.get_skill("bangumi")
+    assert bangumi is not None
+    assert "latest_episode" in {action.name for action in bangumi.actions}
+
+
+@pytest.mark.asyncio
+async def test_latest_episode_reports_latest_aired_main_episode(monkeypatch) -> None:
+    """latest_episode selects the newest episode whose airdate is not future."""
+    module = importlib.import_module(
+        "openlist_ani.builtin_skills.skills.bangumi.script.latest_episode",
+    )
+
+    class FakeBangumiClient:
+        def __init__(self, access_token: str = "") -> None:
+            self.access_token = access_token
+
+        async def fetch_subject(self, subject_id: int):
+            assert subject_id == 377130
+            return SimpleNamespace(
+                id=subject_id,
+                display_name="尖帽子的魔法工房",
+            )
+
+        async def fetch_subject_episodes(self, subject_id: int, episode_type: int = 0):
+            assert subject_id == 377130
+            assert episode_type == 0
+            return [
+                {
+                    "id": 1656038,
+                    "type": 0,
+                    "name": "誰が為の魔法",
+                    "name_cn": "魔法为谁而放",
+                    "sort": 7,
+                    "ep": 7,
+                    "airdate": "2026-05-18",
+                },
+                {
+                    "id": 1656040,
+                    "type": 0,
+                    "name": "黒に沈む悪夢",
+                    "name_cn": "",
+                    "sort": 9,
+                    "ep": 9,
+                    "airdate": "2026-06-01",
+                },
+                {
+                    "id": 1656039,
+                    "type": 0,
+                    "name": "魔警団の疑念",
+                    "name_cn": "",
+                    "sort": 8,
+                    "ep": 8,
+                    "airdate": "2026-05-25",
+                },
+            ]
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(module, "BangumiClient", FakeBangumiClient)
+
+    result = await module.run(subject_id="377130", as_of_date="2026-05-26")
+
+    assert "# Latest aired episode for 尖帽子的魔法工房" in result
+    assert "As of: 2026-05-26" in result
+    assert "Episode: ep.8" in result
+    assert "Episode ID: 1656039" in result
+    assert "Airdate: 2026-05-25" in result
+    assert "Title: 魔警団の疑念" in result
+
+
+@pytest.mark.asyncio
+async def test_latest_episode_reports_no_aired_episode(monkeypatch) -> None:
+    """latest_episode explains when all known main episodes are in the future."""
+    module = importlib.import_module(
+        "openlist_ani.builtin_skills.skills.bangumi.script.latest_episode",
+    )
+
+    class FakeBangumiClient:
+        def __init__(self, access_token: str = "") -> None:
+            pass
+
+        async def fetch_subject(self, subject_id: int):
+            return SimpleNamespace(id=subject_id, display_name="未开播动画")
+
+        async def fetch_subject_episodes(self, subject_id: int, episode_type: int = 0):
+            return [
+                {
+                    "id": 1,
+                    "type": 0,
+                    "name": "第1话",
+                    "sort": 1,
+                    "ep": 1,
+                    "airdate": "2026-06-01",
+                },
+            ]
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(module, "BangumiClient", FakeBangumiClient)
+
+    result = await module.run(subject_id="123", as_of_date="2026-05-26")
+
+    assert (
+        "No aired main-story episodes found for 未开播动画 as of 2026-05-26." in result
+    )
+    assert "Known main-story episodes: 1" in result

--- a/tests/assistant/test_bangumi_latest_episode_skill.py
+++ b/tests/assistant/test_bangumi_latest_episode_skill.py
@@ -77,9 +77,6 @@ async def test_latest_episode_reports_latest_aired_main_episode(monkeypatch) -> 
 
     result = await module.run(subject_id="377130")
 
-    fake_client.fetch_subject.assert_awaited_once_with(377130)
-    fake_client.fetch_subject_episodes.assert_awaited_once_with(377130, episode_type=0)
-    fake_client.close.assert_awaited_once_with()
     assert "# Latest aired episode for 尖帽子的魔法工房" in result
     assert "As of: 2026-05-26" in result
     assert "Episode: ep.8" in result
@@ -119,9 +116,6 @@ async def test_latest_episode_reports_no_aired_episode(monkeypatch) -> None:
 
     result = await module.run(subject_id="123")
 
-    fake_client.fetch_subject.assert_awaited_once_with(123)
-    fake_client.fetch_subject_episodes.assert_awaited_once_with(123, episode_type=0)
-    fake_client.close.assert_awaited_once_with()
     assert (
         "No aired main-story episodes found for 未开播动画 as of 2026-05-26." in result
     )

--- a/tests/assistant/test_bangumi_latest_episode_skill.py
+++ b/tests/assistant/test_bangumi_latest_episode_skill.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import importlib
+from datetime import date
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -29,21 +31,15 @@ async def test_latest_episode_reports_latest_aired_main_episode(monkeypatch) -> 
         "openlist_ani.builtin_skills.skills.bangumi.script.latest_episode",
     )
 
-    class FakeBangumiClient:
-        def __init__(self, access_token: str = "") -> None:
-            self.access_token = access_token
-
-        async def fetch_subject(self, subject_id: int):
-            assert subject_id == 377130
-            return SimpleNamespace(
-                id=subject_id,
+    fake_client = SimpleNamespace(
+        fetch_subject=AsyncMock(
+            return_value=SimpleNamespace(
+                id=377130,
                 display_name="尖帽子的魔法工房",
-            )
-
-        async def fetch_subject_episodes(self, subject_id: int, episode_type: int = 0):
-            assert subject_id == 377130
-            assert episode_type == 0
-            return [
+            ),
+        ),
+        fetch_subject_episodes=AsyncMock(
+            return_value=[
                 {
                     "id": 1656038,
                     "type": 0,
@@ -71,15 +67,19 @@ async def test_latest_episode_reports_latest_aired_main_episode(monkeypatch) -> 
                     "ep": 8,
                     "airdate": "2026-05-25",
                 },
-            ]
+            ],
+        ),
+        close=AsyncMock(),
+    )
 
-        async def close(self) -> None:
-            return None
+    monkeypatch.setattr(module, "BangumiClient", lambda access_token="": fake_client)
+    monkeypatch.setattr(module, "_today_utc8", lambda: date(2026, 5, 26))
 
-    monkeypatch.setattr(module, "BangumiClient", FakeBangumiClient)
+    result = await module.run(subject_id="377130")
 
-    result = await module.run(subject_id="377130", as_of_date="2026-05-26")
-
+    fake_client.fetch_subject.assert_awaited_once_with(377130)
+    fake_client.fetch_subject_episodes.assert_awaited_once_with(377130, episode_type=0)
+    fake_client.close.assert_awaited_once_with()
     assert "# Latest aired episode for 尖帽子的魔法工房" in result
     assert "As of: 2026-05-26" in result
     assert "Episode: ep.8" in result
@@ -95,15 +95,12 @@ async def test_latest_episode_reports_no_aired_episode(monkeypatch) -> None:
         "openlist_ani.builtin_skills.skills.bangumi.script.latest_episode",
     )
 
-    class FakeBangumiClient:
-        def __init__(self, access_token: str = "") -> None:
-            pass
-
-        async def fetch_subject(self, subject_id: int):
-            return SimpleNamespace(id=subject_id, display_name="未开播动画")
-
-        async def fetch_subject_episodes(self, subject_id: int, episode_type: int = 0):
-            return [
+    fake_client = SimpleNamespace(
+        fetch_subject=AsyncMock(
+            return_value=SimpleNamespace(id=123, display_name="未开播动画"),
+        ),
+        fetch_subject_episodes=AsyncMock(
+            return_value=[
                 {
                     "id": 1,
                     "type": 0,
@@ -112,15 +109,19 @@ async def test_latest_episode_reports_no_aired_episode(monkeypatch) -> None:
                     "ep": 1,
                     "airdate": "2026-06-01",
                 },
-            ]
+            ],
+        ),
+        close=AsyncMock(),
+    )
 
-        async def close(self) -> None:
-            return None
+    monkeypatch.setattr(module, "BangumiClient", lambda access_token="": fake_client)
+    monkeypatch.setattr(module, "_today_utc8", lambda: date(2026, 5, 26))
 
-    monkeypatch.setattr(module, "BangumiClient", FakeBangumiClient)
+    result = await module.run(subject_id="123")
 
-    result = await module.run(subject_id="123", as_of_date="2026-05-26")
-
+    fake_client.fetch_subject.assert_awaited_once_with(123)
+    fake_client.fetch_subject_episodes.assert_awaited_once_with(123, episode_type=0)
+    fake_client.close.assert_awaited_once_with()
     assert (
         "No aired main-story episodes found for 未开播动画 as of 2026-05-26." in result
     )

--- a/tests/assistant/test_builtin_tools.py
+++ b/tests/assistant/test_builtin_tools.py
@@ -88,6 +88,7 @@ class TestSkillTool:
         assert tool.is_concurrency_safe({"action": "search"}) is True
         assert tool.is_concurrency_safe({"action": "query"}) is True
         assert tool.is_concurrency_safe({"action": "calendar"}) is True
+        assert tool.is_concurrency_safe({"action": "latest_episode"}) is True
         assert tool.is_concurrency_safe({"action": "subgroups"}) is True
         assert tool.is_concurrency_safe({"action": "default"}) is True
         # Write actions


### PR DESCRIPTION
## Summary
- add a Bangumi `latest_episode` builtin skill action for latest aired main-story episodes
- teach the Bangumi skill guide when to call the new action after search
- mark the action as read-only for assistant skill-tool scheduling

## Verification
- `uv run pytest tests/assistant/test_bangumi_latest_episode_skill.py tests/assistant/test_builtin_tools.py tests/assistant/test_skill_catalog.py tests/assistant/test_skill_installer.py -q`
- `uv run ruff check src/openlist_ani/builtin_skills/skills/bangumi/script/latest_episode.py src/openlist_ani/assistant/tool/builtin/skill_tool.py tests/assistant/test_bangumi_latest_episode_skill.py tests/assistant/test_builtin_tools.py`
- `uv run black --check --target-version py311 src/openlist_ani/builtin_skills/skills/bangumi/script/latest_episode.py src/openlist_ani/assistant/tool/builtin/skill_tool.py tests/assistant/test_bangumi_latest_episode_skill.py tests/assistant/test_builtin_tools.py`
- manual API smoke test: `latest_episode(subject_id=377130, as_of_date=2026-05-26)` returned ep.8 / episode ID 1656039